### PR TITLE
Playoffs links work for seasons without a post-season / Write the hash in the empty state; accept tab=playoffs for any season / Issue #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ A conference view is `#season=2026-27&age=GU16&conf=NorCal`, optionally with
 `&view=schedule`, `&team=<teamID>` (the team shown in the glance panel) and
 `&sched=results` or `&sched=all` (the match filter; upcoming is the default).
 
+Playoffs is `#tab=playoffs&season=2026-27`, with `&stage=`, `&age=` and `&tier=`
+appended once the season has national events.
+
 ## Layout
 
 | Path | What it is |

--- a/public/index.html
+++ b/public/index.html
@@ -2306,7 +2306,7 @@
           if (s.ageGroup) currentAgeGroup = s.ageGroup; // validated after API fetch
           if (SEASONS[currentSeason].conferences[s.conference]) currentConference = s.conference;
           if (s.view === 'schedule' || s.view === 'standings') currentView = s.view;
-          if (s.tab === 'playoffs' && NATIONAL_EVENTS[currentSeason]) currentTab = 'playoffs';
+          if (s.tab === 'playoffs') currentTab = 'playoffs';
           if (s.tab === 'favorites' && favorites.size) currentTab = 'favorites';
           if (s.favorite && favorites.has(s.favorite)) currentFavorite = s.favorite;
           if (s.stage) currentPlayoffStage = s.stage;              // validated in buildStageTabs
@@ -2354,8 +2354,11 @@
       const view = currentView !== 'standings' ? `&view=${e(currentView)}` : '';
       const fav = currentFavorite ? favoriteMeta.get(currentFavorite) : previewTeam;
       const h = currentTab === 'playoffs'
-        ? `#tab=playoffs&season=${e(currentSeason)}&stage=${e(currentPlayoffStage || '')}` +
-          `&age=${e(currentPlayoffAgeGroup || '')}&tier=${e(currentPlayoffTier || '')}${view}`
+        // stage/age/tier are unset when the season has no national events yet
+        ? `#tab=playoffs&season=${e(currentSeason)}` +
+          (currentPlayoffStage ? `&stage=${e(currentPlayoffStage)}` : '') +
+          (currentPlayoffAgeGroup ? `&age=${e(currentPlayoffAgeGroup)}` : '') +
+          (currentPlayoffTier ? `&tier=${e(currentPlayoffTier)}` : '') + view
         : currentTab === 'favorites'
         ? `#tab=teams&season=${e(currentSeason)}` +
           (fav && fav.teamID ? `&team=${e(fav.teamID)}` : '') + (fav ? `&name=${e(fav.name)}` : '')
@@ -2386,7 +2389,7 @@
         currentFavorite = rec ? rec.name : null;
         return true;
       }
-      if (p.get('tab') === 'playoffs' && NATIONAL_EVENTS[currentSeason]) {
+      if (p.get('tab') === 'playoffs') {
         currentTab = 'playoffs';
         if (p.get('stage')) currentPlayoffStage = p.get('stage');     // validated in buildStageTabs
         if (p.get('age')) currentPlayoffAgeGroup = p.get('age');       // validated in loadPlayoffsPanel
@@ -2777,6 +2780,10 @@
               ? 'The national playoffs run at the end of the season. Results appear here once TGS publishes them.'
               : 'This season\'s national events were not archived.'}</div>
           </div>`;
+        currentPlayoffStage = null;
+        currentPlayoffAgeGroup = null;
+        currentPlayoffTier = null;
+        saveState(); pushHash();
         return;
       }
 


### PR DESCRIPTION
## Goal

Resolve issue #1: *Playoffs tab for a season with no post-season does not update the URL hash.*

For a season with no post-season yet (currently 2026-27), clicking **🏆 Playoffs** shows the "not played yet" empty state but leaves the previous view's hash in the address bar, so reloading or sharing the link lands on the wrong tab. The reverse also fails: opening `#tab=playoffs&season=2026-27` falls back to the conference view. This PR makes the empty state a first-class, linkable view without changing anything for seasons that have brackets.

**Branch:** `fix/1-playoffs-hash` (from `main` @ `d86e0d1`) · **Plan approved by** @zhenyisx on 2026-09-09 (see the issue).

## Summary of change

`public/index.html` (+11 / −4) and one README note.

- `pushHash()` playoffs branch: append `&stage=`, `&age=`, `&tier=` only when set. Previously they were always emitted, as `&stage=&age=&tier=` when null.
- `loadPlayoffsPanel()` no-national-events branch: reset `currentPlayoffStage` / `currentPlayoffAgeGroup` / `currentPlayoffTier` to `null`, then `saveState(); pushHash();` before the early `return` (mirrors the My Teams empty state).
- `loadFromHash()` (also used by `hashchange`): drop the `&& NATIONAL_EVENTS[currentSeason]` guard so `tab=playoffs` always selects the Playoffs tab; the panel already renders the correct empty state.
- `loadSavedState()`: drop the same guard, so a saved Playoffs tab restores consistently.
- `README.md`: document `#tab=playoffs&season=2026-27` next to the other hash formats.

## Testing plan

**Syntax:** main `<script>` body extracted and compiled with `node -e "new Function(body)"` — OK.

**Playwright** (Python, system Chrome, 1400px) against `python -m http.server` serving this branch's `public/`, plus a second server serving a copy with `main`'s `index.html` as the baseline. Each case does `goto(url#hash)` then `reload()` so the hash is honoured on load.

| # | Case | Result |
|---|---|---|
| 1 | `#season=2026-27&age=GU16&conf=NorCal` → click Playoffs | PASS — hash `#tab=playoffs&season=2026-27`, Playoffs tab active, subtitle "2026–27 · not played yet", empty state rendered |
| 2 | `#tab=teams&season=2026-27` → click Playoffs | PASS — same hash, Playoffs active |
| 3 | Deep link `#tab=playoffs&season=2026-27` | PASS — Playoffs active, empty state, conferences panel hidden, no standings table |
| 4 | Deep link `#tab=playoffs&season=2025-26` | PASS — `#tab=playoffs&season=2025-26&stage=Playoffs%20%26%20Finals&age=G2009&tier=39382`, 54 bracket matches |
| 4b | Same on unmodified `main` | PASS — byte-identical hash and bracket count (no regression for seasons with events) |
| 5 | On Playoffs 2025-26, season → 2026-27 → 2025-26 | PASS — empty-state hash, then the full hash and bracket again |
| 5b | Same transition by editing the URL (`hashchange`) | PASS |
| 6 | Console errors across all cases | PASS — only the pre-existing `/favicon.ico` 404 (tracked in #5) |

Screenshots of case 1 and case 4 were reviewed. Manual re-check on the live site by the Website Auditor is planned after deploy.

## Potential risks and suggestions

- **Hash format change is one-directional.** Only the empty state's hash changes (it drops the empty `stage`/`age`/`tier` parameters). Old links of the form `#tab=playoffs&season=2026-27&stage=&age=&tier=` still parse: `loadFromHash` already maps empty values to `null`.
- **Season selector was exercised through a hidden control.** On the Playoffs tab the only season `<select>` lives in the hidden Conferences panel, so case 5 used `select_option(force=True)`. That is the UI gap tracked as #2, recommended as the next task.
- **No automated test suite exists in the repo.** The Playwright script lives outside the repo; if this pattern repeats, consider committing a small `tests/` smoke script so future PRs reuse it.

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
