### PR TITLE
Team search finds a team in any age group / search every division, memoize standings, group results by age group / For Issue #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ upstream API or website ever goes away.
 - **CSV exports** — Human-readable standings and schedule tables under `export/`, openable in Excel
 - **Playoffs & Finals** — National post-season per age group and competition (Champions League, North American Cup, Showcase Cup, Showcase Games): knockout brackets drawn as trees, cup and consolation brackets, group tables where a group stage exists, round-tagged schedules, and a format note per competition
 - **★ My Teams** — Follow any team; each favorite opens a summary page: the glance panel, the full table with the team highlighted, the team's own fixtures and results, and its post-season games when it played any
-- **One team search** — Find a team across every conference in the current season and age group; a result opens it on its conference page, already selected
+- **One team search** — Find a team across every age group and conference in the current season; a result opens it on its conference page with the age group and team selected
 - **Age group navigation** — Tabs populated from the API; keyboard arrow-key navigation, `/` to search
 - **Dark mode**, and **deep links** (season, age group, conference, view, selected team and match filter in the URL hash)
 - **Data explained** — Standings state that the order is as published by TGS (points per game, then goal difference), the header shows when the data was observed, and every view links to its source page on TGS

--- a/public/index.html
+++ b/public/index.html
@@ -1805,6 +1805,18 @@
 
     .search-results-table tbody tr:last-child td { border-bottom: none; }
 
+    .search-group-row { cursor: default; }
+    .search-group-row[hidden] { display: none; }
+    .search-group-row td {
+      padding: 6px 12px;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--text-secondary);
+      background: var(--bg-surface-alt);
+    }
+
     .search-conf-badge {
       display: inline-block;
       font-size: 10px;
@@ -1917,8 +1929,8 @@
         <div class="sidebar-section-title">Find a team</div>
         <div class="sidebar-search global-search-wrap" role="search">
           <input type="search" class="search-input" id="globalTeamSearch"
-            placeholder="Team or club name…" autocomplete="off"
-            aria-label="Find a team in any conference"
+            placeholder="Team or club, any age group…" autocomplete="off"
+            aria-label="Find a team in any age group or conference"
             oninput="onGlobalSearchInput(this.value)"
             onkeydown="if(event.key==='Escape')clearGlobalSearch()">
           <button type="button" class="global-search-clear" id="globalSearchClear"
@@ -2231,10 +2243,20 @@
     // flight as two blocks — an unnamed group holding one or two teams beside
     // "Group A" with the rest (seven 2021-22 U13 flights, three in 2022-23) —
     // so the blocks are merged; see mergeStandingsBlocks.
+    // Memoised per session by request path (in ?live=1 mode too, like
+    // eventHierarchy) so a search across every division and the conference
+    // page that follows share one fetch per flight; a rejection is evicted so
+    // the next call retries. opts.refresh bypasses the memo.
+    const standingsMemo = {};
     async function getStandings(divId, flightId, eventId, opts) {
-      const data = await fetchJSON(`Event/get-standings-by-div-and-flight/${divId}/${flightId}/${eventId}`, opts);
-      const blocks = Array.isArray(data.data) ? data.data : (data.data ? [data.data] : []);
-      return mergeStandingsBlocks(blocks) || data.data || data;
+      const key = `Event/get-standings-by-div-and-flight/${divId}/${flightId}/${eventId}`;
+      if (standingsMemo[key] && !(opts && opts.refresh)) return standingsMemo[key];
+      const p = fetchJSON(key, opts).then(data => {
+        const blocks = Array.isArray(data.data) ? data.data : (data.data ? [data.data] : []);
+        return mergeStandingsBlocks(blocks) || data.data || data;
+      });
+      standingsMemo[key] = p.catch(e => { delete standingsMemo[key]; throw e; });
+      return standingsMemo[key];
     }
 
     // Keeps the largest block's published order and slots every other block's
@@ -2461,6 +2483,7 @@
     }
 
     function clearGlobalSearch({ reload = true } = {}) {
+      clearTimeout(globalSearchDebounce);
       const inp = document.getElementById('globalTeamSearch');
       if (inp) inp.value = '';
       const clearBtn = document.getElementById('globalSearchClear');
@@ -2472,31 +2495,37 @@
       }
     }
 
+    let searchToken = 0;          // drops results from a search that was superseded
+
     async function searchAllConferences(query) {
-      if (!currentAgeGroup) return;
+      if (!AGE_GROUPS.length) return;
       globalSearchActive = true;
+      const token = ++searchToken;
+      ++loadToken;                // a conference load still in flight must not paint over the results
+      const live = () => token === searchToken && globalSearchActive;
       const q = query.toLowerCase();
 
       // Update header
       document.getElementById('breadcrumb').innerHTML =
         `<span>${currentSeason}</span><span class="breadcrumb-sep">›</span>` +
-        `<span>${AGE_LABELS[currentAgeGroup] || currentAgeGroup}</span><span class="breadcrumb-sep">›</span>` +
-        `<span class="breadcrumb-current">Search: "${query}"</span>`;
+        `<span class="breadcrumb-current">Search: "${esc(query)}"</span>`;
       document.getElementById('contentTitle').textContent = `Search results for "${query}"`;
-      document.getElementById('contentSubtitle').textContent = `${currentSeason} · ${AGE_LABELS[currentAgeGroup] || currentAgeGroup} · all conferences`;
+      document.getElementById('contentSubtitle').textContent = `${currentSeason} · all age groups · all conferences`;
       document.getElementById('extLinks').innerHTML = '';
 
       const container = document.getElementById('standingsContainer');
       const conferences = Object.entries(getSeasonData().conferences);
       const total = conferences.length;
+      const groups = AGE_GROUPS.slice();   // oldest first, as the tabs
       let done = 0;
 
-      // Show progress panel immediately
+      // Show progress panel immediately: one body per age group, its header
+      // row hidden until the group has a match
       container.innerHTML = `
         <div class="search-results-panel" id="searchResultsPanel">
           <div class="search-results-header">
-            <div class="search-results-title">🔍 "${query}"</div>
-            <div class="search-results-count" id="searchResultsCount" role="status" aria-live="polite">Searching ${total} conferences…</div>
+            <div class="search-results-title">🔍 "${esc(query)}"</div>
+            <div class="search-results-count" id="searchResultsCount" role="status" aria-live="polite">Searching ${total} conferences · ${groups.length} age groups…</div>
           </div>
           <div class="search-progress" id="searchProgress">
             <span id="searchProgressText">0 / ${total}</span>
@@ -2504,59 +2533,70 @@
           </div>
           <table class="search-results-table" id="searchResultsTable">
             <thead>${standingsHeadHtml(SEARCH_COLS, null, null, false)}</thead>
-            <tbody id="searchResultsTbody"></tbody>
+            ${groups.map(ag => {
+              const by = birthYearLabel(ag);
+              return `<tbody data-age="${esc(ag)}"><tr class="search-group-row" aria-hidden="true" hidden>` +
+                `<td colspan="${SEARCH_COLS.length}">${esc(AGE_LABELS[ag] || ag)}${by ? ' · ' + esc(by) : ''}</td></tr></tbody>`;
+            }).join('')}
           </table>
         </div>`;
 
-      const tbody = document.getElementById('searchResultsTbody');
       let totalMatches = 0;
 
-      // Fetch all conferences in parallel, append results as each arrives
+      // A result row goes into its age group's body, kept sorted by conference name
+      const addRow = (ag, confName, flight, team, rank) => {
+        const group = container.querySelector(`tbody[data-age="${CSS.escape(ag)}"]`);
+        if (!group) return;
+        const tmp = document.createElement('tbody');
+        tmp.innerHTML = standingsRowHtml(team, SEARCH_COLS, {
+          rank, selectable: true, ctx: { confName, flightName: flight.flightName },
+        });
+        const row = tmp.firstElementChild;
+        row.dataset.conf = confName;
+        row.dataset.age = ag;
+        row.title = `Open ${displayName(team.name, team.clubName)} in ${AGE_LABELS[ag] || ag} · ${confName}`;
+        const open = () => {
+          clearGlobalSearch({ reload: false });
+          openTeamInContext({ season: currentSeason, ageGroup: ag, confName, teamID: team.teamID });
+        };
+        row.addEventListener('click', e => { if (!e.target.closest('.star-btn')) open(); });
+        row.addEventListener('keydown', e => {
+          if ((e.key === 'Enter' || e.key === ' ') && e.target === row) { e.preventDefault(); open(); }
+        });
+        group.firstElementChild.hidden = false;
+        const next = [...group.querySelectorAll('tr[data-conf]')].find(r => r.dataset.conf.localeCompare(confName) > 0);
+        group.insertBefore(row, next || null);
+      };
+
+      // Fetch every division of every conference in parallel, append results as each arrives
       const fetchPromises = conferences.map(async ([confName, conf]) => {
         try {
           const hierarchy = await getEventHierarchy(conf.eventId);
           const divList = hierarchy.girlsDivAndFlightList || [];
-          const division = divList.find(d => d.divisionName === currentAgeGroup);
-          if (!division) return;
-
-          const flights = division.flightList || [];
-          const standingsResults = await Promise.all(
-            flights.map(f =>
-              getStandings(division.divisionID, f.flightID, conf.eventId)
-                .then(data => ({ flight: f, data }))
-                .catch(() => null)
-            )
-          );
-
-          standingsResults.forEach(result => {
-            if (!result || !result.data) return;
-            const teams = result.data.teamStandings || [];
-            teams.forEach((team, i) => {
-              if (!team.name.toLowerCase().includes(q)) return;
-              totalMatches++;
-              const tmp = document.createElement('tbody');
-              tmp.innerHTML = standingsRowHtml(team, SEARCH_COLS, {
-                rank: i + 1, selectable: true, ctx: { confName, flightName: result.flight.flightName },
+          await Promise.all(groups.map(async ag => {
+            const division = divList.find(d => d.divisionName === ag);
+            if (!division) return;
+            const standingsResults = await Promise.all(
+              (division.flightList || []).map(f =>
+                getStandings(division.divisionID, f.flightID, conf.eventId)
+                  .then(data => ({ flight: f, data }))
+                  .catch(() => null)
+              )
+            );
+            if (!live()) return;
+            standingsResults.forEach(result => {
+              if (!result || !result.data) return;
+              (result.data.teamStandings || []).forEach((team, i) => {
+                if (!`${team.name || ''} ${team.clubName || ''}`.toLowerCase().includes(q)) return;
+                totalMatches++;
+                addRow(ag, confName, result.flight, team, i + 1);
               });
-              const row = tmp.firstElementChild;
-              row.dataset.conf = confName;
-              row.title = `Open ${displayName(team.name, team.clubName)} in ${confName}`;
-              const open = () => {
-                clearGlobalSearch({ reload: false });
-                openTeamInContext({ season: currentSeason, ageGroup: currentAgeGroup, confName, teamID: team.teamID });
-              };
-              row.addEventListener('click', e => { if (!e.target.closest('.star-btn')) open(); });
-              row.addEventListener('keydown', e => {
-                if ((e.key === 'Enter' || e.key === ' ') && e.target === row) { e.preventDefault(); open(); }
-              });
-              if (tbody) tbody.appendChild(row);
-              const countEl = document.getElementById('searchResultsCount');
-              if (countEl) countEl.textContent = `${totalMatches} match${totalMatches !== 1 ? 'es' : ''}`;
             });
-          });
+          }));
         } catch (e) { /* skip failed conference */ }
 
         done++;
+        if (!live()) return;
         const pText = document.getElementById('searchProgressText');
         const pFill  = document.getElementById('searchProgressFill');
         if (pText) pText.textContent = `${done} / ${total}`;
@@ -2564,20 +2604,23 @@
       });
 
       await Promise.all(fetchPromises);
+      if (!live()) return;
 
       // Hide progress bar when done
       const prog = document.getElementById('searchProgress');
       if (prog) prog.style.display = 'none';
 
+      const summary = `${totalMatches} match${totalMatches !== 1 ? 'es' : ''} across ${groups.length} age groups · ${total} conferences`;
       const countEl = document.getElementById('searchResultsCount');
-      if (countEl) countEl.textContent = `${totalMatches} match${totalMatches !== 1 ? 'es' : ''} found`;
+      if (countEl) countEl.textContent = summary;
 
-      if (totalMatches === 0 && tbody) {
-        tbody.innerHTML = `<tr><td colspan="11"><div class="search-no-results-msg">No teams found matching "${query}"</div></td></tr>`;
+      if (totalMatches === 0) {
+        const table = document.getElementById('searchResultsTable');
+        if (table) table.insertAdjacentHTML('beforeend', `<tbody><tr><td colspan="${SEARCH_COLS.length}"><div class="search-no-results-msg">` +
+          `No teams found matching "${esc(query)}" in any age group or conference (${esc(currentSeason)})</div></td></tr></tbody>`);
       }
 
-      document.getElementById('globalSearchStatus').textContent =
-        `${totalMatches} match${totalMatches !== 1 ? 'es' : ''} across ${total} conferences`;
+      document.getElementById('globalSearchStatus').textContent = summary;
     }
 
     // ========== SIDEBAR ==========

--- a/public/index.html
+++ b/public/index.html
@@ -1805,9 +1805,13 @@
 
     .search-results-table tbody tr:last-child td { border-bottom: none; }
 
-    .search-group-row { cursor: default; }
+    .search-results-table .search-group-row { cursor: default; }
     .search-group-row[hidden] { display: none; }
-    .search-group-row td {
+    .search-group-row th {
+      position: static;
+      text-align: left;
+      white-space: normal;
+      border-bottom: 1px solid var(--border-light);
       padding: 6px 12px;
       font-size: 11px;
       font-weight: 600;
@@ -2255,8 +2259,9 @@
         const blocks = Array.isArray(data.data) ? data.data : (data.data ? [data.data] : []);
         return mergeStandingsBlocks(blocks) || data.data || data;
       });
-      standingsMemo[key] = p.catch(e => { delete standingsMemo[key]; throw e; });
-      return standingsMemo[key];
+      const entry = p.catch(e => { if (standingsMemo[key] === entry) delete standingsMemo[key]; throw e; });
+      standingsMemo[key] = entry;
+      return entry;
     }
 
     // Keeps the largest block's published order and slots every other block's
@@ -2516,7 +2521,9 @@
       const container = document.getElementById('standingsContainer');
       const conferences = Object.entries(getSeasonData().conferences);
       const total = conferences.length;
-      const groups = AGE_GROUPS.slice();   // oldest first, as the tabs
+      // Oldest first, as the tabs. AGE_GROUPS comes from the first conference's
+      // hierarchy; a division named differently in another conference is skipped.
+      const groups = AGE_GROUPS.slice();
       let done = 0;
 
       // Show progress panel immediately: one body per age group, its header
@@ -2535,13 +2542,14 @@
             <thead>${standingsHeadHtml(SEARCH_COLS, null, null, false)}</thead>
             ${groups.map(ag => {
               const by = birthYearLabel(ag);
-              return `<tbody data-age="${esc(ag)}"><tr class="search-group-row" aria-hidden="true" hidden>` +
-                `<td colspan="${SEARCH_COLS.length}">${esc(AGE_LABELS[ag] || ag)}${by ? ' · ' + esc(by) : ''}</td></tr></tbody>`;
+              return `<tbody data-age="${esc(ag)}"><tr class="search-group-row" hidden>` +
+                `<th scope="colgroup" colspan="${SEARCH_COLS.length}">${esc(AGE_LABELS[ag] || ag)}${by ? ' · ' + esc(by) : ''}</th></tr></tbody>`;
             }).join('')}
           </table>
         </div>`;
 
       let totalMatches = 0;
+      const matchedAges = new Set(), matchedConfs = new Set();
 
       // A result row goes into its age group's body, kept sorted by conference name
       const addRow = (ag, confName, flight, team, rank) => {
@@ -2589,6 +2597,7 @@
               (result.data.teamStandings || []).forEach((team, i) => {
                 if (!`${team.name || ''} ${team.clubName || ''}`.toLowerCase().includes(q)) return;
                 totalMatches++;
+                matchedAges.add(ag); matchedConfs.add(confName);
                 addRow(ag, confName, result.flight, team, i + 1);
               });
             });
@@ -2610,7 +2619,11 @@
       const prog = document.getElementById('searchProgress');
       if (prog) prog.style.display = 'none';
 
-      const summary = `${totalMatches} match${totalMatches !== 1 ? 'es' : ''} across ${groups.length} age groups · ${total} conferences`;
+      // Counts the age groups and conferences that have a hit, not the ones searched
+      const n = (count, one, many) => `${count} ${count === 1 ? one : many}`;
+      const summary = totalMatches === 0
+        ? `0 matches (${groups.length} age groups · ${total} conferences searched)`
+        : `${n(totalMatches, 'match', 'matches')} in ${n(matchedAges.size, 'age group', 'age groups')} · ${n(matchedConfs.size, 'conference', 'conferences')}`;
       const countEl = document.getElementById('searchResultsCount');
       if (countEl) countEl.textContent = summary;
 
@@ -4067,12 +4080,17 @@
     }
 
     function selectView(view) {
-      if (view === currentView) return;
+      // Leaving search mode: the results panel owns the breadcrumb, title and
+      // container, so rebuild the view with one loadCurrentView (fetches are
+      // memoised) instead of clearGlobalSearch's own reload plus a render here.
+      const leavingSearch = globalSearchActive;
+      if (leavingSearch) clearGlobalSearch({ reload: false });
+      else if (view === currentView) return;
       currentView = view;
       const s = document.getElementById('viewTabStandings');
       updateViewTabsUI(s ? s.textContent : undefined);
       if (currentTab === 'playoffs') loadPlayoffFlight();
-      else if (currentConfMeta && currentFlightData.length) { renderConferenceView(); saveState(); pushHash(); }
+      else if (!leavingSearch && currentConfMeta && currentFlightData.length) { renderConferenceView(); saveState(); pushHash(); }
       else loadCurrentView();
     }
 


### PR DESCRIPTION
## Goal

Resolve #7. The sidebar "Find a team" search only looked in the currently selected age group, so searching "Solar" while on U16 showed one row and the other five Solar teams were only reachable by re-running the search on each tab. The search now covers every age group and every conference of the season in one pass, groups the results by age group (oldest first, matching the tabs), also matches on the club name, and a result opens the team on its own age-group + conference page with the team selected.

Closes #7

## Summary of change

Files: `public/index.html`, `README.md` (CRLF preserved).

- `getStandings` — memoised per session by request path (`standingsMemo`), also in `?live=1` mode like `eventHierarchy`; a rejected fetch is evicted so the next call retries; `opts.refresh` bypasses the memo. A repeat search and the conference page that a result opens now issue no new standings requests.
- `searchAllConferences` — guards on `AGE_GROUPS.length` instead of `currentAgeGroup`; takes a `searchToken` and bumps `loadToken` at start, and every DOM write (progress, rows, count, final status, empty state) is gated on `token === searchToken && globalSearchActive`; iterates `AGE_GROUPS` in tab order and `find`s each conference's division by `divisionName`; matches `${team.name} ${team.clubName}` with null-safe names; renders one `<tbody data-age>` per age group with a `.search-group-row` header (`U16 · G2010/11`, non-focusable, no `data-team-id`) that is unhidden on the first match; rows carry `data-age`/`data-conf`, are inserted sorted by conference name, and open via `openTeamInContext({ season, ageGroup: ag, confName, teamID })`. Breadcrumb drops the age group; subtitle is `season · all age groups · all conferences`; empty state names the season. The query is `esc()`ed in every HTML string; hard-coded `colspan="11"` replaced by `SEARCH_COLS.length`. No age column added to `SEARCH_COLS`.
- `clearGlobalSearch` — also clears the pending debounce, so clearing the box right after typing cannot resurrect the search 300 ms later (needed for the race hardening above).
- CSS — `.search-group-row` (muted, 11px, uppercase, letter-spaced, `--bg-surface-alt`, default cursor) and its `[hidden]` state.
- Search input — placeholder "Team or club, any age group…", `aria-label="Find a team in any age group or conference"`.
- README — "One team search" bullet updated.

Review round (second commit, `1833e9b`):

- Accessibility: the group header row no longer carries `aria-hidden`; its cell is `<th scope="colgroup" colspan="${SEARCH_COLS.length}">`, so screen readers announce the age group. Still non-focusable, no `data-team-id`, `hidden` until the group has a match. The `.search-group-row th` rule also sets `position: static` / a 1px bottom border / `white-space: normal` to override the generic sticky `.search-results-table th` rule, so it looks exactly as before.
- Cursor: `.search-results-table .search-group-row { cursor: default }` now outranks `.search-results-table tbody tr { cursor: pointer }`.
- Memo eviction guard: `const entry = p.catch(e => { if (standingsMemo[key] === entry) delete standingsMemo[key]; throw e; })` — an older failure can no longer evict a newer in-flight entry for the same key.
- Count wording: status and panel count now count the age groups and conferences that have a hit — `6 matches in 6 age groups · 1 conference`, `1 match in 1 age group · 1 conference`; zero matches reads `0 matches (6 age groups · 10 conferences searched)`. The in-progress text still says `Searching 10 conferences · 6 age groups…`.
- `selectView`: when `globalSearchActive`, calls `clearGlobalSearch({ reload: false })` and goes through `loadCurrentView()` once (fetches are memoised), also when the clicked view is already the current one. The `reload: true` variant was rejected because `clearGlobalSearch → loadStandings → loadCurrentView` resets `currentFlightData`/`currentConfMeta` synchronously, so `selectView` would then call `loadCurrentView` a second time.
- One-line comment at the `AGE_GROUPS` iteration: the list comes from the first conference's hierarchy; a division named differently in another conference is skipped.

## Testing plan

Local static server (`python -m http.server` in `public/`), Playwright + system Chrome, 1400×900 unless noted. Clicks dispatched via `page.evaluate` (the live-updating table makes real clicks time out). Re-run in full after the review round: 40 checks, 40 pass.

- [x] JS syntax: main `<script>` body extracted and compiled with `new Function(body)` — OK (128,373 chars).
- [x] Case 1 (2026-27, from `#age=GU16&conf=Mid-Atlantic`, search "Solar"): 6 rows, `data-age` = GU13, GU14, GU15, GU16, GU17, GU18/19; all badged Texas; group headers visible for exactly those 6 groups (`U18/19 · G2008/09` … `U13 · G2013/14`), headers `tabindex=-1` with no `data-team-id`; tbody order equals `AGE_GROUPS`; breadcrumb `2026-27 › Search: "Solar"`; subtitle `2026-27 · all age groups · all conferences`; count and status both `6 matches in 6 age groups · 1 conference`. Fill → final status: 0.42 s.
- [x] Review: every header row's cell is `TH` with `scope="colgroup"`, `colspan="11"` (= `SEARCH_COLS.length`), `getAttribute('aria-hidden') === null`, computed `position: static`; `getComputedStyle(headerRow).cursor === 'default'` on all 6 visible headers; result rows still `pointer`.
- [x] Review, fewer groups: the rarest team name in the memoised standings (`Arlington Soccer Association ECNL G2010/11`) → 1 row, one visible header, status `1 match in 1 age group · 1 conference` (Mid-Atlantic, GU16).
- [x] Review, view tab while results are shown (on Texas U13 after case 2, search "Solar", dispatch click on the Matches tab): no `#searchResultsPanel`, sidebar status `''`, input `''`, `globalSearchActive === false`, `currentView === 'schedule'`, Matches tab active, `.matches-panel` rendered, breadcrumb `2026-27 › U13 › Texas`; `loadCurrentView` called exactly once and `renderConferenceView` exactly once (wrapped counters); 0 new standings requests, 1 schedule request. Same-view variant (Standings tab clicked while standings is already the current view during a search) → also leaves search mode with one load / one render.
- [x] Case 2 (dispatch click on the GU13 Solar row): hash `#season=2026-27&age=GU13&conf=Texas&team=69973`; active age tab `GU13`; active conference `Texas`; row 69973 highlighted; glance panel shows "SOLAR SC · Texas · Girls U13"; sidebar status cleared.
- [x] Case 3 ("VDA"): 6 results, first is `VDA ECNL G2008/09` (Mid-Atlantic, GU18/19), status `6 matches in 6 age groups · 1 conference`. "Virginia Development" (club name only) returned the same 6 VDA rows in the first pass, confirming the club-name match.
- [x] Case 4 (`#seasonSelect` → 2025-26, search "Solar"): ages `G2008/2007, G2009, G2010, G2011, G2012, G2013` (birth-year style, different from case 1); subtitle carries 2025-26. 0.40 s.
- [x] Case 5 memo: repeat of the same query → 0 new `get-standings-by-div-and-flight` requests (131 → 131). Before/after vs. main (first pass): main issues 11 standings requests per search and 12 again on a repeat, plus 1 when opening a result; this branch issues 64 on the first search (all 6 divisions × 10 conferences), 0 on a repeat, 0 when opening a result. Eviction: `page.route` aborting the two Texas standings files for one division → that Solar row missing (`5 matches in 5 age groups · 1 conference`, 2 aborts seen); `unroute_all` + re-search → both files refetched and the row is back (6 matches).
- [x] Case 6 race: type "Solar", `clearGlobalSearch()` immediately, click Mid-Atlantic, wait 2 s → status `''`, `#standingsContainer` shows the standings table and no search panel. Variant with the debounce already fired and a conference clicked mid-search → same result.
- [x] Case 7 keyboard: focus a result row, Enter → `#season=2025-26&age=G2013&conf=Texas&team=59794`, active tab G2013.
- [x] Empty state: "zzqxv" → `No teams found matching "zzqxv" in any age group or conference (2025-26)`, status `0 matches (6 age groups · 10 conferences searched)`.
- [x] Query escaping (first pass): `<img src=x onerror=…>` as the query renders as text in the title, no image element created, no handler run.
- [x] Conference sort (first pass): "FC" (234 matches) → within every age-group body the rows are non-decreasing by `data-conf`.
- [x] Case 8 console/page errors across all cases: only `/favicon.ico` 404 (×2) and the two `net::ERR_FAILED` from the deliberate abort in case 5; no page errors.
- [x] Screenshots: case 1 at 1400 px, case 1 at 390 px, case 2 landing page (kept locally).
- [x] `git diff --stat origin/main...HEAD`: only `public/index.html` (177 lines changed) and `README.md` (+1/−1); `index.html` still 4,572 CRLF lines, 0 bare LF.
- [ ] Not run: `?live=1` mode against the real API (memo path is the same code, exercised via the archive files); dark theme only checked by CSS tokens, not screenshotted.
- [ ] Website Auditor verifies live after merge

## Potential risks and suggestions

- The first search now fetches every division's standings (≈64 small files vs 11); locally that is sub-second and cached afterwards, but on a cold CDN it is more requests. The memo also means the conference page after a search costs nothing extra.
- With the memo, `?live=1` mode no longer refetches standings per navigation within a session — the same policy `eventHierarchy` already follows. `opts.refresh: true` bypasses the memo, but no caller passes it today, so a live-mode reload is the only way to see fresher standings.
- Memoised standings objects are shared between the search and the conference view; the only in-place mutation in the app is `_origRank = i + 1`, which is idempotent, and every sort copies first — checked, but a future in-place sort would leak between views.
- Progress is still counted per conference (`done / 10`), not per division; fine for the bar, just less granular than the work it represents.
- Mobile (390 px): the results table is wider than the panel (582 px vs 364 px) and `.search-results-panel` is `overflow: hidden`, so the Flight/GP…GD columns are clipped with no horizontal scroll. Pre-existing for the search panel (the body itself does not scroll); worth a follow-up to let the panel scroll horizontally.
- #13 (deleting down to one character wipes the input) is untouched and still reproduces; tracked separately.
- The dropped-debounce line in `clearGlobalSearch` is a small behaviour change beyond the plan: previously clearing the box within 300 ms of typing could re-open the results panel with an empty input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
