### PR TITLE
Shared links open the same view for everyone / keys omitted from a hash reset to their defaults in loadFromHash / For Issue #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ A conference view is `#season=2026-27&age=GU16&conf=NorCal`, optionally with
 `&sched=results` or `&sched=all` (the match filter; upcoming is the default).
 
 Playoffs is `#tab=playoffs&season=2026-27`, with `&stage=`, `&age=` and `&tier=`
-appended once the season has national events.
+appended once the season has national events. Keys omitted from a link take their defaults (Standings, upcoming matches, no selected team; for Playoffs the first stage, age group and competition) rather than the viewer's last state.
 
 ## Layout
 

--- a/public/index.html
+++ b/public/index.html
@@ -2418,9 +2418,11 @@
       }
       if (p.get('tab') === 'playoffs') {
         currentTab = 'playoffs';
-        if (p.get('stage')) currentPlayoffStage = p.get('stage');     // validated in buildStageTabs
-        if (p.get('age')) currentPlayoffAgeGroup = p.get('age');       // validated in loadPlayoffsPanel
-        if (p.get('tier')) currentPlayoffTier = Number(p.get('tier')) || null;
+        // Keys the link omits fall back to the first stage / age group / competition
+        if (!p.has('view')) currentView = 'standings';
+        currentPlayoffStage = p.get('stage') || null;                  // validated in buildStageTabs
+        currentPlayoffAgeGroup = p.get('age') || null;                 // validated in loadPlayoffsPanel
+        currentPlayoffTier = Number(p.get('tier')) || null;
         return true;
       }
       currentTab = 'conferences';
@@ -2428,7 +2430,13 @@
       if (p.get('conf') && SEASONS[currentSeason].conferences[p.get('conf')]) { currentConference = p.get('conf'); changed = true; }
       if (p.get('team')) { selectedTeamID = Number(p.get('team')) || null; changed = true; } // validated once the tables load
       if (['upcoming', 'results', 'all'].includes(p.get('sched'))) { scheduleFilter = p.get('sched'); changed = true; }
-      return changed;
+      if (!changed) return false;   // an unknown-only hash such as #foo stays a no-op
+      // A link describes the whole view: what it omits is the default, not what
+      // this browser showed last (same-document navigation reuses live state).
+      if (!p.has('view')) currentView = 'standings';
+      if (!p.has('sched')) scheduleFilter = 'upcoming';
+      if (!p.has('team')) selectedTeamID = null;
+      return true;
     }
 
     window.addEventListener('hashchange', () => {


### PR DESCRIPTION
> **Correction (TPM, 2026-09-10):** this PR merged at `21ce41c`. The review-round commit `3edfaa3` (season-only links also reset age group and conference; README wording and wrap) was pushed after the merge and is **not** in `main`; it is delivered separately as PR for issue #18. The Summary and Testing plan below include that commit.

## Goal

Resolve #8. A shared link should open the same view for everyone. A fresh load was already fine: `init` runs `loadSavedState()` only when there is no hash. The leak was same-document hash navigation (pasting a link into an open tab, an in-page `href="#…"`, an automated `goto`): `loadFromHash()` only overwrote the keys present in the hash, so `view`, `sched` and `team` kept the live in-memory values, the `hashchange` handler re-rendered from them, and `pushHash` then rewrote the address bar with the viewer's sticky view (`…&view=schedule&sched=results`). Reproduced against `origin/main` before the change.

Closes #8

## Summary of change

- `loadFromHash` (conferences branch): `return changed` becomes `if (!changed) return false;` (an unknown-only hash such as `#foo` stays a no-op) followed by a reset of every key the link omits: `view` → `'standings'`, `sched` → `'upcoming'`, `team` → `null`. Defaults are the declared initial values of `currentView` / `scheduleFilter` / `selectedTeamID`.
- Second commit (review follow-up): the same branch also resets `age` and `conf` to `null` when the link omits them, so a season-only link (`#season=2026-27`) behaves the same on a same-document navigation as on a fresh load. `rebuildAll` already repairs a null age group / conference to `AGE_GROUPS[0]` / the first conference of the season (Mid-Atlantic), and `loadCurrentView` returns early on a null conference, so no downstream change was needed. `pushHash` always emits `age` and `conf` for the conferences tab, so in-app navigation never produces such a hash.
- `loadFromHash` (playoffs branch): `view` resets to `'standings'` when absent; `stage`, `age` and `tier` now always take the hash value or `null` instead of keeping the live value. `null` is already handled downstream: `buildStageTabs` falls back to `keys[0]`, `loadPlayoffsPanel` to `groups[0]`, `loadPlayoffFlight` to `flights[0].flightID`, so an omitted key means "the first stage / age group / competition". No changes were needed there.
- Because the reset flows through the normal `saveState()` path, following a deep link now also updates the viewer's saved view: state is what you see. (Previously the saved view survived the link and re-surfaced on the next unhashed load.)
- No change to `loadSavedState`, `saveState`, `pushHash`, the `hashchange` handler or `init`.
- README (My Teams / deep-link section): one sentence on omitted keys taking their defaults, wrapped to the paragraph width.

Diff: `public/index.html` +15/−4 (all inside `loadFromHash`), `README.md` +4/−1 (one sentence). No EOL churn.

## Testing plan

Playwright (python, system Chrome) against `python -m http.server` serving `public/`, asserting on `currentView` / `scheduleFilter` / `selectedTeamID` / `currentAgeGroup` / `currentConference` / `location.hash` / the active `#viewTabs .view-tab` / rendered rows. Saved state seeded into `localStorage['ecnl-dash-v2-state']`. Same-document navigation = `page.goto('/#…')` from the open page; fresh load = `goto` + `reload`. 16/16 checks pass on the second commit.

- [x] Baseline on `origin/main`: seeded Matches/results, same-document `#season=2026-27&age=GU16&conf=NorCal` → stayed `view=schedule sched=results`, hash rewritten to `…&conf=NorCal&view=schedule&sched=results` (bug reproduced)
- [x] 1 Bug path: seeded state restores Matches/results on a fresh unhashed load (`view=schedule sched=results conf=Texas`, tab "Matches", 10 rows); then same-document `#season=2026-27&age=GU16&conf=NorCal` → `view=standings sched=upcoming team=None`, tab "Standings", 1 standings table, `location.hash` exactly `#season=2026-27&age=GU16&conf=NorCal`; saved state now `view=standings sched=upcoming`
- [x] 2 Fresh-load guard: sticky saved schedule + `goto(link)` + `reload()` → Standings, `conf=NorCal age=GU16`
- [x] 3 `…&view=schedule&sched=results` (reloaded) → Matches/results, 17 result rows, hash preserved
- [x] 4 hashchange: from `…conf=NorCal&view=schedule` (reloaded) to `…conf=Texas` → Standings / Texas; browser Back → NorCal Matches restored (115 rows, hash `…conf=NorCal&view=schedule`)
- [x] 5a (updated) same-document `#season=2026-27` from a Texas/GU17 Matches(all) view → conferences tab, Standings, upcoming, `age=GU18/19` (= `AGE_GROUPS[0]` for 2026-27), `conf=Mid-Atlantic` (first conference), 1 standings table, `location.hash` rewritten to `#season=2026-27&age=GU18%2F19&conf=Mid-Atlantic`
- [x] 5c (new, consistency) fresh load of `#season=2026-27` with sticky Texas/GU17 Matches(all) saved state → identical to 5a on tab/view/sched/team/age/conf/hash/active tab (`age=GU18/19 conf=Mid-Atlantic`, hash `#season=2026-27&age=GU18%2F19&conf=Mid-Atlantic`)
- [x] 5b `#foo` → `loadFromHash()` returns `false`, no re-render (DOM marker intact), state unchanged (`view=schedule sched=results conf=Texas`), hash stays `#foo`
- [x] 6 Playoffs: from a conference Matches view, same-document `#tab=playoffs&season=2025-26` → Playoffs tab, `currentView=standings` ("Bracket" tab active), stage `Playoffs & Finals`, age `G2009`, tier `39382`, hash `#tab=playoffs&season=2025-26&stage=Playoffs%20%26%20Finals&age=G2009&tier=39382` (no `view=`); `…&view=schedule` → Schedule view, same first stage/age/tier; `#tab=playoffs&season=2026-27` → empty state, `currentView=standings`, stage/age/tier `null`, hash exactly `#tab=playoffs&season=2026-27`
- [x] 7 Glance round trip: NorCal GU16 Matches, `selectTeam(55477)` → hash `…&view=schedule&team=55477`; click "Full team page →" (`#tab=teams&season=2026-27&team=55477&name=MVLA…`) → My Teams renders "MVLA ECNL G2010/11"; Back → conferences, `view=schedule team=55477`, glance panel present
- [x] 8 `#tab=teams&season=2025-26&team=46900` (reloaded) → My Teams, "FC Dallas ECNL G08/07" renders
- [x] 9 In-app regression guard: on Matches, click another conference item (→ Mid-Atlantic) and another age tab (→ GU18/19) → still Matches, hash keeps `view=schedule` (`#season=2026-27&age=GU18%2F19&conf=Mid-Atlantic&view=schedule`)
- [x] 10 Console: only `Failed to load resource: 404` (favicon.ico); no page errors
- [x] `node` syntax check of the main `<script>` body via `new Function(body)` (129,094 chars): OK
- [x] `git diff --stat origin/main...HEAD`: `README.md | 5 ++++-`, `public/index.html | 19 +++++++++++++++----`; 0 CR bytes in the diff
- [ ] Not run: `#tab=teams` links from a browser where the team IS a favourite (the teams branch of `loadFromHash` is untouched); mobile layout; the live site
- [ ] Website Auditor verifies live after merge

## Potential risks and suggestions

- Editing only `conf=` (or `age=`) in the address bar while on Matches now lands on Standings, since the edited hash omits `view=`. Intended: the hash is the whole view. Copying the address bar always includes `age=`/`conf=`/`view=`/`sched=`/`team=` when they are set or non-default, so links copied from the bar still round-trip.
- With the second commit, a hand-typed `#season=2026-27` (or deleting `age=`/`conf=` from the bar) jumps to the first age group (currently GU18/19 for 2026-27) and Mid-Atlantic instead of keeping the live age group / conference. This matches what a fresh load of the same link already did; the only in-app hashes are written by `pushHash`, which always carries both keys.
- Following a deep link now overwrites the viewer's saved view. That is the "state = what you see" behaviour agreed on the issue, but a user who habitually lives in Matches and opens a Standings link will come back to Standings on their next unhashed visit.
- The playoffs `stage`/`age`/`tier` reset means an in-page `#tab=playoffs&season=…` link without those keys jumps back to the first stage/age/competition. The only such link in the app is `pushHash` itself, which emits them whenever they are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

