### PR TITLE
Season-only links open the same view for everyone / omitted age and conference reset to the first age group and conference in loadFromHash / For Issue #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,10 @@ A conference view is `#season=2026-27&age=GU16&conf=NorCal`, optionally with
 `&sched=results` or `&sched=all` (the match filter; upcoming is the default).
 
 Playoffs is `#tab=playoffs&season=2026-27`, with `&stage=`, `&age=` and `&tier=`
-appended once the season has national events. Keys omitted from a link take their defaults (Standings, upcoming matches, no selected team; for Playoffs the first stage, age group and competition) rather than the viewer's last state.
+appended once the season has national events. Keys omitted from a link take
+their defaults (Standings, upcoming matches, no selected team — the glance panel
+falls back to a favourite, if any; for Playoffs the first stage, age group and
+competition) rather than the viewer's last state.
 
 ## Layout
 

--- a/public/index.html
+++ b/public/index.html
@@ -2433,6 +2433,9 @@
       if (!changed) return false;   // an unknown-only hash such as #foo stays a no-op
       // A link describes the whole view: what it omits is the default, not what
       // this browser showed last (same-document navigation reuses live state).
+      // A null age group / conference is repaired to the first one by rebuildAll.
+      if (!p.has('age')) currentAgeGroup = null;
+      if (!p.has('conf')) currentConference = null;
       if (!p.has('view')) currentView = 'standings';
       if (!p.has('sched')) scheduleFilter = 'upcoming';
       if (!p.has('team')) selectedTeamID = null;


### PR DESCRIPTION
## Goal

Resolve #18: a season-only link (`#season=2026-27`) pasted into an open tab kept that browser's live age group and conference, while a fresh load of the same link opened the first age group and Mid-Atlantic. Same leak class as #8, for the two keys #8 did not reset. This change was implemented, reviewed and tested as the follow-up round of PR #17, which the owner merged before the round landed; it is delivered here as its own PR.

Closes #18

## Summary of change

- `public/index.html`, `loadFromHash` conferences branch (after `if (!changed) return false;`): `if (!p.has('age')) currentAgeGroup = null; if (!p.has('conf')) currentConference = null;` — `rebuildAll` repairs null to the first age group (`AGE_GROUPS[0]`, the oldest) and the first conference (Mid-Atlantic); `loadCurrentView` tolerates a null conference. `pushHash` always emits `age`/`conf` and uses `replaceState`, so in-app navigation never reaches this path.
- `README.md`: the deep-link sentence now says the glance panel falls back to a favourite, if any, and is wrapped to the paragraph width.

## Testing plan

- [x] Node syntax check of the main `<script>` body (`new Function(body)`, 129,094 chars): OK.
- [x] Same-document `#season=2026-27` from a Texas / GU17 / Matches (all) state → conferences tab, Standings, upcoming, age `GU18/19`, conference `Mid-Atlantic`, one standings table, hash rewritten to `#season=2026-27&age=GU18%2F19&conf=Mid-Atlantic`.
- [x] Fresh load of `#season=2026-27` with the same sticky saved state → identical result on all eight fields (consistency, the point of the fix).
- [x] Regression guard: on Matches, click another conference then an age tab → still Matches, hash keeps `view=schedule`.
- [x] All #8 cases (bug path, fresh-load guard, explicit view/sched, hashchange + Back, `#foo` no-op, Playoffs with/without `view` and the 2026-27 empty state, glance-link Back round trip, My Teams deep link) still pass: 16/16.
- [x] Console: only the `/favicon.ico` 404; no page errors.
- [x] `git diff --stat origin/main...HEAD`: `README.md` +4/−1, `public/index.html` +3; no CR bytes in the diff.
- [ ] Website Auditor verifies live after merge

## Potential risks and suggestions

- A link with only `season=` now always opens U18/19 · Mid-Atlantic for everyone, whatever the viewer was looking at. That is the intended "a link describes the whole view" rule; the README documents the season + age + conference form as the normal link.
- The follow-up also updates PR #17's README sentence; PR #17's body was corrected to state that this commit was not part of its merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
