### PR TITLE
Season can be changed from the Playoffs tab / season select moved to a shared sidebar block, hidden on My Teams, one-tap link to the latest brackets on the empty state / For Issue #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ hardcoded in the HTML.
 3. Archive it: `python archive.py --season 2026-27`
 
 The season dropdown rebuilds itself from the registry, so no HTML edit is needed.
+It sits above the sidebar tabs and is available on Conferences and Playoffs (My
+Teams hides it, since a favorite belongs to one season).
 
 ## National playoffs
 
@@ -152,7 +154,8 @@ Playoffs is `#tab=playoffs&season=2026-27`, with `&stage=`, `&age=` and `&tier=`
 appended once the season has national events. Keys omitted from a link take
 their defaults (Standings, upcoming matches, no selected team — the glance panel
 falls back to a favourite, if any; for Playoffs the first stage, age group and
-competition) rather than the viewer's last state.
+competition) rather than the viewer's last state. The season can be changed from
+the Playoffs tab; the tab is kept and the hash follows the new season.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ hardcoded in the HTML.
 3. Archive it: `python archive.py --season 2026-27`
 
 The season dropdown rebuilds itself from the registry, so no HTML edit is needed.
-It sits above the sidebar tabs and is available on Conferences and Playoffs (My
-Teams hides it, since a favorite belongs to one season).
+It sits under the sidebar tabs, above the tab panels, and is available on
+Conferences and Playoffs (My Teams hides it, since a favorite belongs to one
+season).
 
 ## National playoffs
 

--- a/public/index.html
+++ b/public/index.html
@@ -288,8 +288,10 @@
       padding: 6px 16px 4px;
     }
     .browse-row .browse-label { padding: 0; min-width: 52px; }
-    /* Season row above the tab panels; the tab strip supplies the border */
-    .sidebar-season { padding: 6px 16px 10px; background: var(--bg-surface-alt); }
+    /* Season row under the tab strip, above the tab panels; the strip supplies
+       the border, and the negative margin swallows its 4px gap so the tinted
+       block sits flush against it (the gap is kept for My Teams). */
+    .sidebar-season { margin-top: -4px; padding: 6px 16px 10px; background: var(--bg-surface-alt); }
     .season-select {
       flex: 1;
       min-width: 0;
@@ -2001,7 +2003,7 @@
         <div class="content-header-row">
           <div class="content-header-main">
             <div class="breadcrumb" id="breadcrumb"></div>
-            <h1 class="content-title" id="contentTitle">Select a conference</h1>
+            <h1 class="content-title" id="contentTitle" tabindex="-1">Select a conference</h1>
             <div class="content-subtitle" id="contentSubtitle">Choose an age group and conference from the sidebar</div>
           </div>
           <div class="content-header-right">
@@ -2828,6 +2830,13 @@
       ).join('');
     }
 
+    // The Playoffs empty-state button lives in #standingsContainer, which
+    // loadPlayoffsPanel replaces, so focus would fall back to <body>; park it
+    // on the page title instead (tabindex="-1" keeps it out of the Tab order).
+    function focusContentTitle() {
+      document.getElementById('contentTitle').focus({ preventScroll: true });
+    }
+
     async function loadPlayoffsPanel() {
       const natEvents = getNationalEventsForSeason();
 
@@ -2836,8 +2845,8 @@
         // with no `national` entry was simply never archived.
         const notYet = SOURCES.refresh && currentSeason === SOURCES.refresh.activeSeason;
         const label = seasonLabel(currentSeason);
-        // Newest season with archived brackets, in the registry's order
-        const latest = Object.keys(SEASONS).find(s => NATIONAL_EVENTS[s]) || null;
+        // Newest season with archived brackets (YYYY-YY keys sort lexically)
+        const latest = Object.keys(NATIONAL_EVENTS).sort().reverse()[0] || null;
         document.getElementById('breadcrumb').innerHTML =
           `<span>${esc(currentSeason)}</span><span class="breadcrumb-sep">›</span><span class="breadcrumb-current">Playoffs & Finals</span>`;
         document.getElementById('contentTitle').textContent = 'Playoffs & Finals';
@@ -2854,8 +2863,8 @@
             <div class="no-national-events-text">${notYet ? `${label} Playoffs &amp; Finals haven't been played yet` : `${label} playoff data isn't available here`}</div>
             <div class="no-national-events-sub">${notYet
               ? 'The national playoffs run at the end of the season. Results appear here once TGS publishes them.'
-              : 'This season\'s national events were not archived.'} Choose another season in the sidebar to see past brackets.</div>
-            ${latest ? `<button type="button" class="btn-primary" data-season="${esc(latest)}" onclick="changeSeason(this.dataset.season)">See the ${esc(seasonLabel(latest))} brackets</button>` : ''}
+              : 'This season\'s national events were not archived.'} Choose another season to see past brackets.</div>
+            ${latest ? `<button type="button" class="btn-primary" data-season="${esc(latest)}" onclick="changeSeason(this.dataset.season).then(focusContentTitle)">See the ${esc(seasonLabel(latest))} brackets</button>` : ''}
           </div>`;
         currentPlayoffStage = null;
         currentPlayoffAgeGroup = null;

--- a/public/index.html
+++ b/public/index.html
@@ -288,6 +288,8 @@
       padding: 6px 16px 4px;
     }
     .browse-row .browse-label { padding: 0; min-width: 52px; }
+    /* Season row above the tab panels; the tab strip supplies the border */
+    .sidebar-season { padding: 6px 16px 10px; background: var(--bg-surface-alt); }
     .season-select {
       flex: 1;
       min-width: 0;
@@ -1148,7 +1150,8 @@
     /* Comfortable targets on touch screens */
     @media (max-width: 768px), (pointer: coarse) {
       .age-tab, .conference-item, .view-tab, .sidebar-tab, .seg-btn, .stage-tab, .playoff-age-tab,
-      .more-stats-btn, .open-external, .btn-primary, .theme-toggle, .hamburger, .wordmark, .section-label {
+      .more-stats-btn, .open-external, .btn-primary, .theme-toggle, .hamburger, .wordmark, .section-label,
+      .season-select {
         min-height: 44px;
       }
       .star-btn { min-width: 40px; min-height: 40px; }
@@ -1929,6 +1932,14 @@
         <button class="sidebar-tab" id="tabPlayoffs" role="tab" aria-selected="false" aria-controls="playoffsPanel" onclick="switchTab('playoffs')">🏆 Playoffs</button>
       </div>
 
+      <!-- Shared by Conferences and Playoffs; My Teams hides it because a
+           favourite is bound to its own season (see changeSeason). -->
+      <div class="browse-row sidebar-season" id="sidebarSeason">
+        <label class="browse-label" for="seasonSelect">Season</label>
+        <!-- Options are built from data/sources.json at startup -->
+        <select class="season-select" id="seasonSelect" onchange="changeSeason(this.value)"></select>
+      </div>
+
       <div id="conferencesPanel" role="tabpanel" aria-labelledby="tabConferences">
         <div class="sidebar-section-title">Find a team</div>
         <div class="sidebar-search global-search-wrap" role="search">
@@ -1943,11 +1954,6 @@
         <div class="global-search-status" id="globalSearchStatus" role="status" aria-live="polite"></div>
 
         <div class="sidebar-section-title">Browse</div>
-        <div class="browse-row">
-          <label class="browse-label" for="seasonSelect">Season</label>
-          <!-- Options are built from data/sources.json at startup -->
-          <select class="season-select" id="seasonSelect" onchange="changeSeason(this.value)"></select>
-        </div>
         <div class="browse-label">Age group</div>
         <div class="age-group-tabs" id="ageGroupTabs" role="tablist" aria-label="Age group"></div>
         <div class="browse-label">Conference</div>
@@ -2691,6 +2697,7 @@
       const isConf = tab === 'conferences';
       const isFav  = tab === 'favorites';
       const isPO   = tab === 'playoffs';
+      document.getElementById('sidebarSeason').style.display    = isFav  ? 'none' : '';
       document.getElementById('conferencesPanel').style.display = isConf ? '' : 'none';
       document.getElementById('favoritesPanel').style.display   = isFav  ? 'flex' : 'none';
       document.getElementById('playoffsPanel').style.display    = isPO   ? 'flex' : 'none';
@@ -2829,6 +2836,8 @@
         // with no `national` entry was simply never archived.
         const notYet = SOURCES.refresh && currentSeason === SOURCES.refresh.activeSeason;
         const label = seasonLabel(currentSeason);
+        // Newest season with archived brackets, in the registry's order
+        const latest = Object.keys(SEASONS).find(s => NATIONAL_EVENTS[s]) || null;
         document.getElementById('breadcrumb').innerHTML =
           `<span>${esc(currentSeason)}</span><span class="breadcrumb-sep">›</span><span class="breadcrumb-current">Playoffs & Finals</span>`;
         document.getElementById('contentTitle').textContent = 'Playoffs & Finals';
@@ -2845,7 +2854,8 @@
             <div class="no-national-events-text">${notYet ? `${label} Playoffs &amp; Finals haven't been played yet` : `${label} playoff data isn't available here`}</div>
             <div class="no-national-events-sub">${notYet
               ? 'The national playoffs run at the end of the season. Results appear here once TGS publishes them.'
-              : 'This season\'s national events were not archived.'}</div>
+              : 'This season\'s national events were not archived.'} Choose another season in the sidebar to see past brackets.</div>
+            ${latest ? `<button type="button" class="btn-primary" data-season="${esc(latest)}" onclick="changeSeason(this.dataset.season)">See the ${esc(seasonLabel(latest))} brackets</button>` : ''}
           </div>`;
         currentPlayoffStage = null;
         currentPlayoffAgeGroup = null;


### PR DESCRIPTION
## Goal

Resolve #2. The season dropdown was part of the Conferences panel, so a viewer on the Playoffs tab had no way to reach past brackets without leaving the tab. The select now lives in a shared sidebar block available on Conferences and Playoffs (hidden on My Teams, where a favourite is bound to its own season), and the Playoffs empty state offers a one-tap link to the latest archived brackets.

Closes #2

## Summary of change

- **Markup** (`public/index.html`): the season `.browse-row` moved out of `#conferencesPanel` into a shared `<div class="browse-row sidebar-season" id="sidebarSeason">` placed between `.sidebar-tabs` and the tab panels; the label/select ids and `onchange="changeSeason(this.value)"` are unchanged, and the "Options are built from data/sources.json" comment moved with it. `#conferencesPanel` keeps its Browse title, now starting with Age group.
- **CSS**: `.sidebar-season { margin-top: -4px; padding: 6px 16px 10px; background: var(--bg-surface-alt); }` (no border; the tab strip already has one). `.season-select` added to the 44px touch-target rule for `(max-width: 768px), (pointer: coarse)`.
- **`switchTab`**: one line, `#sidebarSeason` is `display:none` on My Teams and visible otherwise. `changeSeason` is untouched (its favourites branch stays as a defensive fallback).
- **`loadPlayoffsPanel`** (no-national-events branch): the sub-text gains "Choose another season to see past brackets." and, when the registry has at least one season with national events, a `btn-primary` "See the 2025–26 brackets" button (season formatted like the header). "Latest" is the newest `NATIONAL_EVENTS` key by lexical sort (`Object.keys(NATIONAL_EVENTS).sort().reverse()[0] || null`); the key is carried in `data-season` (HTML-escaped) and the click calls `changeSeason(this.dataset.season).then(focusContentTitle)`, so the Playoffs tab is kept and `syncSeasonUI` updates the select and header label.
- **README.md**: the season dropdown paragraph notes the shared placement (under the sidebar tabs, above the tab panels; Conferences and Playoffs; hidden on My Teams); the Playoffs hash paragraph notes the season can be changed from the Playoffs tab and the tab is kept.

Review round (second commit, `6e82054`):

- **Focus after the CTA**: the button is inside `#standingsContainer`, which `loadPlayoffsPanel` overwrites, so focus dropped to `<body>`. New `focusContentTitle()` helper calls `#contentTitle.focus({ preventScroll: true })` after `changeSeason(...)` resolves; the `<h1>` now carries a static `tabindex="-1"` so it takes script focus without joining the Tab order. `changeSeason` itself is unchanged.
- **Empty-state wording**: "Choose another season to see past brackets." (dropped "in the sidebar", which is a closed drawer on phones).
- **`latest`**: newest `NATIONAL_EVENTS` key by lexical sort instead of relying on `SEASONS` key order; `|| null` and "render the button only when latest exists" are kept.
- **CSS seam**: `.sidebar-tabs { margin-bottom: 4px }` left a 4px strip between the tab strip's border and the tinted block. `.sidebar-season` now has `margin-top: -4px` so it sits flush under the border; the 4px gap remains for My Teams, where the block is hidden, so that tab is pixel-identical to before.
- **README**: placement sentence corrected to "under the sidebar tabs, above the tab panels" (was "above the sidebar tabs"), ~80-col wrap kept.

Not touched: `changeSeason` semantics, `loadFromHash`, `pushHash`, `saveState`, data files, `focusTeamSearch` (its collapsed-sidebar bug is #20).

## Testing plan

Node syntax check of the inline script body (`new Function(body)`): OK (1 inline script, 4603 lines). Python Playwright against system Chrome and `python -m http.server` in `public/`; fresh loads are `goto(url#hash)` then `reload()`. Visibility = element exists, computed `display !== 'none'`, rect width > 0 and fully inside the viewport (plus `.sidebar.open` for the drawer). Review round: 23/24 checks pass; the one failure is the documented 8b native ArrowDown case.

- [x] 1. Desktop 1400px: `#season=2026-27` select visible (display flex, rect 0..279 x 132..182, 10 conferences); `#tab=playoffs&season=2026-27` select visible, Playoffs tab active, empty state shown; `#tab=teams` block `display: none`, My Teams active.
- [x] 1b. Seam (review): `.sidebar-tabs` `getBoundingClientRect().bottom` = 132 and `.sidebar-season` `.top` = 132, gap 0px, on the Playoffs tab in light (`bg rgb(248,249,251)`) and dark (`data-theme="dark"`, `bg rgb(29,33,41)`) themes; crop screenshots of the seam reviewed in both themes.
- [x] 2. Mobile 390×844: `#tab=playoffs&season=2026-27`, click `.hamburger` → `.sidebar.open`, select visible with rect.left = 0 (was −280 closed), height 60 (44px target); after `select_option('2025-26')` the drawer is still open and 54 `.bracket-match` render.
- [x] 3. Playoffs 2026-27 → select 2025-26: Playoffs tab active, 1 stage tab / 5 age tabs / 4 tiers, 54 bracket matches, hash `#tab=playoffs&season=2025-26&stage=Playoffs%20%26%20Finals&age=G2009&tier=39382`, header "2025–26 season". Select 2026-27 → `.no-national-events` with sub-text "The national playoffs run at the end of the season. Results appear here once TGS publishes them. Choose another season to see past brackets." (no "in the sidebar"), CTA text "See the 2025–26 brackets" (`data-season="2025-26"`), hash exactly `#tab=playoffs&season=2026-27`.
- [x] 3b. `latest` (review): `Object.keys(NATIONAL_EVENTS).sort().reverse()[0]` evaluates to `'2025-26'` in the page (keys `['2025-26', '2024-25']`), matching the CTA's `data-season`.
- [x] 4. CTA click → 54 bracket matches, select value `2025-26`, Playoffs tab, same full hash as case 3.
- [x] 4b. Focus (review): after the CTA click `document.activeElement.id === 'contentTitle'` (tag H1, `tabindex="-1"`, title "Champions League — U17 (G2009)", `scrollY` 0). Same via keyboard: focus the button, press Enter → `activeElement.id === 'contentTitle'` (`:focus-visible` true, so keyboard users see the browser's focus ring on the title).
- [x] 5. My Teams: seeded `ecnl-dash-v2-favorites` with a 2025-26 NorCal record (MVLA, eventID 3929); `#tab=teams` → block hidden; open the favourite → select `2025-26`, header "2025–26 season", block still hidden; Conferences tab → block visible showing 2025-26.
- [x] 6. Conferences `#season=2026-27&age=GU16&conf=NorCal` → select 2024-25 → 10 conferences rebuilt, hash `#season=2024-25&age=G2007%2F2006&conf=Mid-Atlantic`, header "2024–25 season" (unchanged behaviour).
- [x] 7. Back/forward: from the full 2025-26 Playoffs hash, `location.hash = '#tab=playoffs&season=2026-27'`, then `history.back()` → select and label 2025-26 with 54 brackets; `history.forward()` → 2026-27 empty state, select 2026-27.
- [x] 8. Keyboard: Tab from `#tabPlayoffs` lands on `#seasonSelect` on both Conferences and Playoffs; `/` on body → `#globalTeamSearch` focused and Conferences active; a dispatched `ArrowDown` keydown on the focused select leaves `currentConference` (NorCal) and season unchanged (typing guard).
- [x] 8b. Observed, not a regression: a real `ArrowDown` key on the focused native `<select>` changes its value in Chrome (native select behaviour) and therefore runs `changeSeason` → 2025-26, which resets the conference to the first one (NorCal → Mid-Atlantic). This was already the case when the select lived in the Conferences panel.
- [x] 9. Console/page errors across all loads: only `/favicon.ico` 404; no page errors.
- [x] Screenshots reviewed: Conferences and Playoffs at 1400px (light), Playoffs 2026-27 empty state with CTA, Playoffs at 390px with the drawer open, dark-theme Playoffs at 1400px, seam crops light + dark.
- [x] `git diff --stat origin/main...HEAD`: only `public/index.html` (+27/−8) and `README.md` (+5/−1); 0 CR bytes in the diff and in both committed blobs.
- [ ] Desktop collapsed-sidebar state was not exercised (the block is inside `.sidebar`, which `display:none`s as a whole).
- [ ] Website Auditor verifies live after merge

## Potential risks and suggestions

- **Layout shift**: the season row now sits above the Find-a-team search on Conferences (previously below it, under Browse), so the search box moves down by one row (~50px) and the Playoffs sidebar gains a row above Stage. The panels keep `flex:1; overflow-y:auto`, so nothing else moves.
- **My Teams hides the select**: chosen because a favourite belongs to one season and opening one switches the season anyway (case 5). To flip it, drop the `sidebarSeason` line in `switchTab`; `changeSeason`'s favourites branch already handles a change from that tab by going to Conferences.
- **Native select keyboard**: ArrowDown on the focused select changes the season immediately in Chrome (8b). Pre-existing; if unwanted, a future change could apply on `change` only after the dropdown closes, but that is outside this issue.
- **Focus ring on the title**: after keyboard activation of the CTA the `<h1>` shows the browser's default `:focus-visible` outline (mouse clicks do not). If that looks off, a `.content-title:focus-visible` style is a one-line follow-up.
- **Negative margin**: `.sidebar-season { margin-top: -4px }` cancels `.sidebar-tabs`' `margin-bottom: 4px` rather than removing it, so My Teams keeps its existing spacing. If a later change drops the strip's margin, this line should go with it.
- **CTA target**: "latest" is the lexically greatest `NATIONAL_EVENTS` key (currently 2025-26), independent of registry order.
- The empty-state hint appears for both the "not played yet" and "not archived" cases, so 2023-24 and earlier also get the 2025-26 button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
