### PR TITLE
Six small polish fixes land together / keyboard hints, drawer aria state, glance touch target, search input, results scroll, collapsed sidebar / For Issues #3, #4, #6, #13, #15, #20

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2688,10 +2688,7 @@
     }
 
     function closeSidebarIfMobile() {
-      if (window.innerWidth <= 768) {
-        document.getElementById('sidebar').classList.remove('open');
-        document.getElementById('sidebarOverlay').classList.remove('visible');
-      }
+      if (isPhone() && document.getElementById('sidebar').classList.contains('open')) toggleSidebar();
     }
 
     function switchTab(tab, { silent = false } = {}) {

--- a/public/index.html
+++ b/public/index.html
@@ -2779,15 +2779,19 @@
         if (el) el.value = '';
       });
       filterTeams('');
-      // Silently reset global search UI (loadStandings is already handling the navigation)
-      globalSearchActive = false;
       clearTimeout(globalSearchDebounce);
-      const gInp = document.getElementById('globalTeamSearch');
-      if (gInp) gInp.value = '';
-      const gClear = document.getElementById('globalSearchClear');
-      if (gClear) gClear.style.display = 'none';
-      const gStatus = document.getElementById('globalSearchStatus');
-      if (gStatus) gStatus.textContent = '';
+      // Silently reset global search UI (loadStandings is already handling the navigation).
+      // onGlobalSearchInput flips the flag before reloading standings when the query
+      // drops under 2 characters, so the letter still being typed survives.
+      if (globalSearchActive) {
+        globalSearchActive = false;
+        const gInp = document.getElementById('globalTeamSearch');
+        if (gInp) gInp.value = '';
+        const gClear = document.getElementById('globalSearchClear');
+        if (gClear) gClear.style.display = 'none';
+        const gStatus = document.getElementById('globalSearchStatus');
+        if (gStatus) gStatus.textContent = '';
+      }
     }
 
     function currentNationalEvent() {

--- a/public/index.html
+++ b/public/index.html
@@ -2502,6 +2502,7 @@
       if (clearBtn) clearBtn.style.display = val.length > 0 ? '' : 'none';
 
       clearTimeout(globalSearchDebounce);
+      globalSearchDebounce = null;
       if (val.trim().length < 2) {
         document.getElementById('globalSearchStatus').textContent =
           val.length === 1 ? 'Type at least 2 characters…' : '';
@@ -2512,11 +2513,15 @@
         return;
       }
       document.getElementById('globalSearchStatus').textContent = 'Searching…';
-      globalSearchDebounce = setTimeout(() => searchAllConferences(val.trim()), 300);
+      globalSearchDebounce = setTimeout(() => {
+        globalSearchDebounce = null;
+        searchAllConferences(val.trim());
+      }, 300);
     }
 
     function clearGlobalSearch({ reload = true } = {}) {
       clearTimeout(globalSearchDebounce);
+      globalSearchDebounce = null;
       const inp = document.getElementById('globalTeamSearch');
       if (inp) inp.value = '';
       const clearBtn = document.getElementById('globalSearchClear');
@@ -2792,11 +2797,15 @@
         if (el) el.value = '';
       });
       filterTeams('');
+      const pending = !!globalSearchDebounce;   // a search still waiting on its 300 ms timer
       clearTimeout(globalSearchDebounce);
+      globalSearchDebounce = null;
       // Silently reset global search UI (loadStandings is already handling the navigation).
       // onGlobalSearchInput flips the flag before reloading standings when the query
-      // drops under 2 characters, so the letter still being typed survives.
-      if (globalSearchActive) {
+      // drops under 2 characters, so the letter still being typed survives. A search that
+      // was still pending on its timer will never run now, so its "Searching…" status and
+      // ✕ button must be cleared here too.
+      if (globalSearchActive || pending) {
         globalSearchActive = false;
         const gInp = document.getElementById('globalTeamSearch');
         if (gInp) gInp.value = '';

--- a/public/index.html
+++ b/public/index.html
@@ -1147,6 +1147,13 @@
       .standings-scroll {
         padding: 16px;
       }
+
+      /* Search results: the table is wider than the panel, so it scrolls sideways
+         inside its own wrapper (the panel keeps overflow hidden for its corners) */
+      .search-results-scroll {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+      }
     }
 
     /* Comfortable targets on touch screens */
@@ -2557,6 +2564,7 @@
             <span id="searchProgressText">0 / ${total}</span>
             <div class="search-progress-bar"><div class="search-progress-fill" id="searchProgressFill" style="width:0%"></div></div>
           </div>
+          <div class="search-results-scroll">
           <table class="search-results-table" id="searchResultsTable">
             <thead>${standingsHeadHtml(SEARCH_COLS, null, null, false)}</thead>
             ${groups.map(ag => {
@@ -2565,6 +2573,7 @@
                 `<th scope="colgroup" colspan="${SEARCH_COLS.length}">${esc(AGE_LABELS[ag] || ag)}${by ? ' · ' + esc(by) : ''}</th></tr></tbody>`;
             }).join('')}
           </table>
+          </div>
         </div>`;
 
       let totalMatches = 0;

--- a/public/index.html
+++ b/public/index.html
@@ -2002,8 +2002,8 @@
 
       <div class="shortcut-hint">
         <span><kbd>/</kbd> Find a team</span>
-        <span><kbd>&larr;</kbd> <kbd>&rarr;</kbd> Age groups</span>
-        <span><kbd>&uarr;</kbd> <kbd>&darr;</kbd> Conferences</span>
+        <span class="hint-conf"><kbd>&larr;</kbd> <kbd>&rarr;</kbd> Age groups</span>
+        <span class="hint-conf"><kbd>&uarr;</kbd> <kbd>&darr;</kbd> Conferences</span>
       </div>
     </div>
 
@@ -2716,6 +2716,8 @@
         b.classList.toggle('active', on);
         b.setAttribute('aria-selected', String(on));
       });
+      // The arrow shortcuts only work on Conferences, so only advertise them there.
+      document.querySelectorAll('.shortcut-hint .hint-conf').forEach(el => { el.hidden = !isConf; });
       if (isFav) openFavoritesTab();
       if (isPO)  loadPlayoffsPanel();
       // Returning to Conferences must repaint the main pane, which the

--- a/public/index.html
+++ b/public/index.html
@@ -1167,7 +1167,7 @@
       .th-sort { min-height: 44px; }
       .standings-table td { padding: 12px 10px; }
       .match-team { padding: 4px 0; }
-      .glance-actions { padding: 0 18px; }
+      .glance-panel .glance-actions { display: flex; align-items: center; padding: 0 18px; }  /* outranks the later base rule */
       .glance-link { display: inline-flex; align-items: center; min-height: 44px; }
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -3366,8 +3366,11 @@
 
     function focusTeamSearch() {
       if (currentTab !== 'conferences') switchTab('conferences');
-      const sb = document.getElementById('sidebar');
-      if (window.innerWidth <= 768 && sb && !sb.classList.contains('open')) toggleSidebar();
+      const sidebar = document.getElementById('sidebar');
+      const hidden = isPhone()
+        ? !sidebar.classList.contains('open')
+        : document.querySelector('.layout').classList.contains('sidebar-collapsed');
+      if (hidden) toggleSidebar();
       const inp = document.getElementById('globalTeamSearch');
       if (inp) { inp.focus(); inp.select(); }
     }

--- a/public/index.html
+++ b/public/index.html
@@ -1167,6 +1167,8 @@
       .th-sort { min-height: 44px; }
       .standings-table td { padding: 12px 10px; }
       .match-team { padding: 4px 0; }
+      .glance-actions { padding: 0 18px; }
+      .glance-link { display: inline-flex; align-items: center; min-height: 44px; }
     }
 
     @media (max-width: 480px) {


### PR DESCRIPTION
## Goal

Resolve #3, #4, #6, #13, #15, #20

- #3: the sidebar footer advertised the arrow-key shortcuts on My Teams and Playoffs, where the keydown handler ignores them.
- #4: on a phone, picking a conference closed the drawer but left the hamburger's `aria-expanded="true"`.
- #6: the "Full team page →" link in the glance panel was a 106×16px touch target on phones.
- #13: deleting a search query down to one character wiped the input, losing the letter still being typed.
- #15: the search results table (582px) clipped inside the 349px panel on phones, hiding Flight / GP / W / L / D / Pts / GD.
- #20: "Find a team" (and the `/` shortcut) did nothing when the desktop sidebar was collapsed; it focused an input inside a `display:none` sidebar.

Closes #3
Closes #4
Closes #6
Closes #13
Closes #15
Closes #20

## Summary of change

- #4 (227b90c): `closeSidebarIfMobile` now calls `toggleSidebar()` when the phone drawer is `.open`, so `setSidebarToggle` keeps `aria-expanded` and the title in sync; the `.open` guard means it never toggles a closed drawer open.
- #20 (4674114): `focusTeamSearch` computes "hidden" per breakpoint (phone: drawer lacks `.open`; desktop: `.layout.sidebar-collapsed`) and calls `toggleSidebar()` before focusing. Both "Find a team" CTAs and the `/` shortcut go through it.
- #13 (9a730a8): `clearTeamFilter` still clears `teamSearch` / `playoffTeamSearch` and the debounce unconditionally, but only resets the global search box, ✕ button, status and flag when `globalSearchActive` is true. `onGlobalSearchInput` flips the flag before reloading standings, so the remaining character survives.
- #15 (854fb3a): the results `<table>` in `searchAllConferences` is wrapped in `<div class="search-results-scroll">`; in the `≤768px` media block that wrapper gets `overflow-x: auto; -webkit-overflow-scrolling: touch`. `.search-results-header` stays outside the wrapper; no overflow rule at desktop widths.
- #6 (ad09f56): in the touch block (`max-width: 768px`, `pointer: coarse`), `.glance-actions { padding: 0 18px }` and `.glance-link { display: inline-flex; align-items: center; min-height: 44px }`. Desktop rules untouched.
- #3 (648a586): the two arrow-key `<span>`s get `class="hint-conf"`; `switchTab` sets `el.hidden = !isConf` on them outside the `!silent` guard, so `goHome`'s silent switch updates them too. `.shortcut-hint span` only sets `white-space`, so nothing overrides `hidden`.

Review round:

- #13 (5f4fdc1): typing "So" and picking a conference inside the 300 ms debounce window left the box holding "So", the ✕ visible and the status stuck at "Searching…" (the timer was cancelled but `globalSearchActive` was still false). The timer callback now sets `globalSearchDebounce = null` before calling `searchAllConferences`; every `clearTimeout(globalSearchDebounce)` (`onGlobalSearchInput`, `clearGlobalSearch`, `clearTeamFilter`) nulls the handle; `clearTeamFilter` computes `const pending = !!globalSearchDebounce` before the `clearTimeout` and resets the search UI when `globalSearchActive || pending`. A single typed letter (no timer) still survives. Comment updated.
- #6 (ecb6929): the touch rule becomes `.glance-panel .glance-actions { display: flex; align-items: center; padding: 0 18px }`. Flex alone did not change the height: the base `.glance-actions { padding: 12px 18px }` at L1341 is declared after the touch block with equal specificity, so the touch-block padding in ad09f56 had never applied (69px = 44 + 12 + 12 + 1). With the descendant selector the row measures 45px on phones, same as desktop, and the 44px link is unchanged. `.glance-actions` contains only the `<a>` (both `<aside class="glance-panel">` builders render it through `glancePanelHtml`), so flex rearranges nothing.

## Testing plan

Local: Python Playwright driving system Chrome against `python -m http.server` in `public/`, fresh browser context per case, `goto` + `reload`, console and page-error collectors on every page. Script: `verify.py` (47 checks, 47 pass; the 37 from round one plus 10 review-round checks).

- [x] Syntax: `new Function(<inline script body>)` in node parses the 130,892-char script.
- [x] #4 at 375×812 on `#season=2026-27&age=GU15&conf=Texas`: hamburger → `.open` + `aria-expanded="true"`; click `.conference-item[data-conf="Midwest"]` → `aria-expanded="false"`, sidebar lacks `.open`, overlay lacks `.visible`. With the drawer closed, clicking Texas keeps `open=false`, `aria="false"`.
- [x] #20 at 1280×800: hamburger → `.layout.sidebar-collapsed`; `switchTab('favorites')` with no favourites shows `#favoritesEmpty`; clicking its `.btn-primary` → collapsed=false, `document.activeElement.id === 'globalTeamSearch'`, `aria-expanded="true"`, tab=conferences. Collapsed again, blur, press `/` → same three values.
- [x] #13 at 1280×800: fill "So" → `#searchResultsPanel`; Backspace → input `'S'`, status `'Type at least 2 characters…'`, `.standings-table` back, `globalSearchActive=false`. With `'S'` typed, clicking Midwest keeps `'S'` + hint. Fill "So" (active), click Texas → input `''`, ✕ hidden. Fill "So", Escape → `''`.
- [x] #13 debounce window (review round): set the input to "So", dispatch `input` (status `'Searching…'`, `globalSearchDebounce !== null`), then 0.5 ms later `.conference-item[data-conf="Midwest"].click()`; after 500 ms → input `''`, ✕ `display: none`, status `''`, no `#searchResultsPanel`, `globalSearchActive === false`, `globalSearchDebounce === null`, conference = Midwest; still no results panel 1.1 s later. Fill "So" then Backspace inside the window, then click Texas → input `'S'` + hint (a cancelled timer no longer counts as pending).
- [x] #15 at 375×812 (drawer, "Solar", drawer closed for measurement): `.search-results-scroll` scrollWidth 582 / clientWidth 349, computed `overflow-x: auto`, `documentElement.scrollWidth` 375, `body.scrollWidth` 375; after `scrollLeft=1000` the wrapper sits at 233 and `.search-results-header` left edge stays at 13; last cell right edge 594.9 → 361.9 (reachable). Panel itself still `overflow-x: hidden`.
- [x] #15 at 1280: `.search-results-table thead th` computed `position: sticky`; `.search-group-row th` `static` (PR #14 intact); wrapper computed `overflow-x: visible`, scrollWidth 942 = clientWidth 942 (no overflow, no new scroll container).
- [x] #6 at 375×812: click first `tr[data-team-id]` → `.glance-link` rect height 44 (width 106, left 31), `.glance-actions` computed `display: flex`, height 45 (was 69 on ad09f56; measured before/after on the same row, link left edge 31 both times), one child. At 1280×800: link height 16, left 971, `.glance-actions` `display: block`, height 45, identical to before.
- [x] #3: cold load `#tab=playoffs&season=2026-27` → both `.hint-conf` `hidden=true`, computed `display: none`, `/ Find a team` still shown; `#tab=teams` → hidden; click Conferences → both `hidden=false`, `display: block`; from Playoffs, `goHome` (silent `switchTab`) → both visible. `goHome` was invoked with a synthetic same-host event because on localhost the real link's host differs and the browser would navigate to the live site.
- [x] Console/page errors across all cases: only `GET /favicon.ico` 404 (confirmed in the http.server log); no page errors.
- [x] `git diff --stat origin/main...HEAD`: `public/index.html` only, 43+/17- (review round alone 13+/4-); zero CR bytes in every commit's blob; eight commits in the order #4 → #20 → #13 → #15 → #6 → #3 → #13 (review) → #6 (review).
- [ ] Not run: real touch device, Safari/iOS (`-webkit-overflow-scrolling` is a no-op on modern iOS but harmless), dark theme screenshots, and keyboard-only traversal of the wrapper.
- [ ] Website Auditor verifies live after merge

## Potential risks and suggestions

- #13 behaviour change: a single typed letter now survives navigation. Changing conference, age group, season, tab or the hash while only one character is in the box keeps that character and the "Type at least 2 characters…" hint; while a search is active (2+ chars) or still pending on the debounce timer, those same actions clear the box as before. `goHome`, opening a result, `selectView`, Escape and ✕ go through `clearGlobalSearch` and still empty it.
- #6: the touch-block override depends on `.glance-actions` being rendered inside `.glance-panel`; a future glance markup that drops that wrapper would fall back to the 12px padding (69px row) but keep the 44px link. Moving the base `.glance-actions` rule above the touch block would remove the need for the descendant selector.
- #15 trade-off on phones: the wrapper is a scroll container, so `.search-results-table th { position: sticky }` sticks relative to the wrapper (i.e. not at all while the page scrolls vertically). This is not a regression: on origin/main the panel's own `overflow: hidden` already traps the sticky header at every width (measured on main and on this branch at 1280×420: thead top 259.4 → −78.6 after scrolling the pane 338px, identical). If a pinned header is wanted, `.search-results-panel { overflow: visible }` plus `border-radius` clipping on the children would be a separate change.
- #15 makes the results table two-axis scrollable on phones (page vertical, wrapper horizontal); no visible scrollbar affordance is added beyond the browser's overlay bar, and there is no left/right fade. Same as the standings table today.
- #20: `toggleSidebar()` on desktop also persists `ecnl-sidebar=open` to localStorage, so "Find a team" from a collapsed sidebar leaves it open on the next visit. That matches what the user would get by clicking the hamburger.
- #4: `closeSidebarIfMobile` now depends on `toggleSidebar`'s phone branch; any future change that makes `toggleSidebar` do desktop work at ≤768px would affect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
