### PR TITLE
Visitors can send feedback to private storage / Worker endpoint with rate limiting, size caps and a committed test harness / For Issue #26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ Thumbs.db
 # archive/ and export/ are deliberately committed — they are the durable local
 # copy of the standings and schedule data, and git gives them dated history.
 *.tmp
+
+# Cloudflare Wrangler build/state directory and any npx-installed packages.
+# The refresh workflow stages everything (git add -A), so neither must ever
+# be committed by a scheduled data run.
+.wrangler/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -231,18 +231,32 @@ and never echoes the submission back.
 | `400` | malformed JSON, bad or missing type, empty message, message over 2000 UTF-16 units, bad email, non-numeric dwell, dwell under the backstop |
 | `403` | `Origin` missing or not `https://ecnl.nextonetwo.com` |
 | `405` (`Allow: POST`) | any other method, including GET, HEAD and OPTIONS |
+| `411` | `Content-Length` absent or not a plain integer — a chunked or unlabelled body is refused before it is read |
 | `413` | `Content-Length` over 8192, or the body exceeds it on read |
 | `415` | content type is not `application/json` (a `; charset=utf-8` parameter is fine) |
-| `429` | the per-address daily limit — checked with a read, never a write |
+| `429` (`Retry-After`) | the per-address daily limit — checked with a read, never a write. `Retry-After` is the seconds left until UTC midnight, when the day-keyed bucket actually resets |
 | `503 {retry:true}` | the KV binding or `FEEDBACK_SALT` is missing, or the global daily cap is reached |
 
 Checks run in that order — method, `Origin`, content type, `Content-Length`, parse,
 honeypot, dwell, then type and length — and **KV is not touched until every one of
-them passes, and is never written on a rejection.** The whole `fetch()` body is
-wrapped in a try/catch whose fallback is `env.ASSETS.fetch(request)`, so a fault in
-this route can never stop the site serving pages; all of the new code lives inside
-the handler, because a throw at module scope would kill every page view and no
-try/catch could save it.
+them passes, and is never written on a rejection.**
+
+The body is never read unbounded. A request must **declare** a `Content-Length` that
+is a plain integer no greater than 8192, or it is refused with `411`/`413` before a
+byte is pulled; and because the header is only a claim, the body is then read through
+a reader that cancels the stream the moment the accumulated byte count crosses the
+cap. A chunked or lying request costs one chunk, not the 100 MB Cloudflare would
+otherwise let it buffer into a 128 MB isolate.
+
+The whole `fetch()` body is wrapped in a catch that **always returns a Response**, so
+a fault in this route can never stop the site serving pages. It is deliberately not a
+bare `env.ASSETS.fetch(request)`: on the feedback path the request body has usually
+already been read, and fetching a consumed `Request` throws, so the feedback path
+returns the same `503 {retry:true}` JSON the client already handles. Every other path
+falls through to the assets inside its own try/catch, so a missing or broken `ASSETS`
+binding degrades to a plain `503` rather than an unhandled rejection. All of the new
+code lives inside the handler, because a throw at module scope would kill every page
+view and no try/catch could save it.
 
 Local dev does not run the Worker at all (`proxy_server.py` implements only GET),
 so the form reports that feedback is unavailable on a local copy. `npx wrangler dev`
@@ -254,6 +268,21 @@ exercises the route against local storage.
   dashboard. This is the only defence that protects the *site*: every page view is
   already a Worker request against the free tier's 100k/day, so a flood on this
   route would take the homepage down before any of our code runs.
+
+  It is also **the only bound on KV read spend**, which matters just as much.
+  Measured against the harness: an accepted submission costs **14 reads and 3
+  writes** (4 address shards + 8 global shards + one read per counter bump; record
+  + two counter shards), and a rate-limited one costs **4 reads and 0 writes**.
+  Two hundred accepted submissions is 2,800 reads of the free 100,000/day, which is
+  comfortable — but 4 reads on the *rejected* path means roughly **25,000 rejected
+  requests exhaust the daily read budget**, and after that the reads themselves fail:
+  the limiter check throws, lands in the outer catch, and the endpoint degrades to
+  `503 {retry:true}` for the rest of the UTC day. Pages keep serving — they are
+  static assets and touch no KV — but feedback stops until midnight. Nothing in
+  this Worker can prevent that, because the spend happens before any of our checks
+  can be cheap enough to matter; only the WAF rule, in front of the route, can.
+  The read and write counts per path are asserted in `worker.test.mjs`, so the
+  arithmetic above cannot drift out of date without a test failing.
 - An **`Origin` allowlist** of the one canonical host, and no CORS headers.
 - A **honeypot** field (`subjectline`) that no human can fill: it returns a normal
   `200` and stores nothing.

--- a/README.md
+++ b/README.md
@@ -179,8 +179,10 @@ the Playoffs tab; the tab is kept and the hash follows the new season.
 ## Deploying
 
 The site is a Cloudflare Worker serving static assets (`wrangler.toml` at the repo
-root: `[assets] directory = "./public"`, plus a ten-line `worker.js` that only
-redirects the `workers.dev` hostname). It is built by Cloudflare's Git integration
+root: `[assets] directory = "./public"`, plus `worker.js`, which redirects the
+`workers.dev` hostname and serves the one dynamic route the site has,
+`POST /api/feedback` (see [Visitor feedback](#visitor-feedback)). It is built
+by Cloudflare's Git integration
 on the **NextOneTwoLabs** Cloudflare account: repository `NextOneTwoLabs/ecnl-dashboard`,
 branch `main`, build command empty, deploy command `npx wrangler deploy`. Pushing to
 `main` — including the scheduled data commits — redeploys.
@@ -200,6 +202,147 @@ Deep-link `#` fragments survive both redirects.
 The `workers.dev` subdomain belongs to the Cloudflare account, not to GitHub — moving
 the repository between GitHub owners does not change the URL, but Cloudflare's GitHub
 App must be installed on the new owner for builds to continue.
+
+## Visitor feedback
+
+`POST /api/feedback` on the Worker takes the "Send feedback" form in the page and
+writes it to a private Cloudflare KV namespace on the same account. Nothing leaves
+our own hosting, there is no third-party form service, and the sender needs no
+account. The maintainers read the submissions, then open ordinary public issues in
+their own words, without personal details.
+
+### The endpoint
+
+JSON in, JSON out. Every response is `Cache-Control: no-store`, never carries an
+`Access-Control-*` header (so a cross-origin browser post cannot read the reply)
+and never echoes the submission back.
+
+```json
+{ "type": "bug", "message": "...", "email": "optional@example.com",
+  "dwell": 4200, "context": { "hash": "#tab=teams", "season": "2025-26",
+  "age": "GU15", "conference": "Midwest", "view": "standings", "tab": "teams" },
+  "viewport": { "w": 390, "h": 844 } }
+```
+
+| Status | When |
+| --- | --- |
+| `200 {ok,id}` | stored |
+| `200 {ok}` | honeypot field filled — nothing is stored, and this is the only silent discard |
+| `400` | malformed JSON, bad or missing type, empty message, message over 2000 UTF-16 units, bad email, non-numeric dwell, dwell under the backstop |
+| `403` | `Origin` missing or not `https://ecnl.nextonetwo.com` |
+| `405` (`Allow: POST`) | any other method, including GET, HEAD and OPTIONS |
+| `413` | `Content-Length` over 8192, or the body exceeds it on read |
+| `415` | content type is not `application/json` (a `; charset=utf-8` parameter is fine) |
+| `429` | the per-address daily limit — checked with a read, never a write |
+| `503 {retry:true}` | the KV binding or `FEEDBACK_SALT` is missing, or the global daily cap is reached |
+
+Checks run in that order — method, `Origin`, content type, `Content-Length`, parse,
+honeypot, dwell, then type and length — and **KV is not touched until every one of
+them passes, and is never written on a rejection.** The whole `fetch()` body is
+wrapped in a try/catch whose fallback is `env.ASSETS.fetch(request)`, so a fault in
+this route can never stop the site serving pages; all of the new code lives inside
+the handler, because a throw at module scope would kill every page view and no
+try/catch could save it.
+
+Local dev does not run the Worker at all (`proxy_server.py` implements only GET),
+so the form reports that feedback is unavailable on a local copy. `npx wrangler dev`
+exercises the route against local storage.
+
+### What stops abuse
+
+- A **WAF rate-limiting rule on `/api/feedback`**, configured in the Cloudflare
+  dashboard. This is the only defence that protects the *site*: every page view is
+  already a Worker request against the free tier's 100k/day, so a flood on this
+  route would take the homepage down before any of our code runs.
+- An **`Origin` allowlist** of the one canonical host, and no CORS headers.
+- A **honeypot** field (`subjectline`) that no human can fill: it returns a normal
+  `200` and stores nothing.
+- A **dwell backstop** of 1000 ms against scripted clients. The value is a number
+  the client sent, not a delay the server observed, so it only stops naive scripts;
+  the 2500 ms gate a human might trip is client-side, where it disables the button
+  instead of throwing the text away. A dwell failure here is a visible `400`, never
+  a silent success.
+- **Size caps:** 8192 bytes of body, 2000 UTF-16 units of message — the same units
+  the client's `maxlength` counts, so an emoji-heavy message cannot pass one and
+  fail the other.
+- **Per-address limiting:** 10 accepted submissions per address per UTC day. The
+  address becomes a key name through `HMAC(HMAC(FEEDBACK_SALT, <UTC date>), address)`,
+  so hashes correlate only within the 24 hours the limiter needs and the address
+  never enters a record. At the limit the reply is `429` after a **read alone**.
+- **A global cap** of 200 accepted submissions a day that **fails closed** with
+  `503 {retry:true}`. Three KV writes per accepted submission (record, address
+  counter, global counter) puts the worst day at 600 of the free tier's 1000
+  writes. Both counters are **sharded** — 8 shards for the global one, 4 per
+  address, one picked at random per write and all of them summed on read — because
+  KV allows only about one write per second per key, and a burst of accepted
+  submissions would otherwise fail on the counter rather than on the record. KV
+  reads are eventually consistent, so the cap can overshoot slightly; at 600 of
+  1000 writes there is headroom for that.
+
+The Workers Rate Limiting binding was considered and not used: it is configured as
+an `[[unsafe.bindings]]` entry, its free-plan availability is not documented, its
+period is limited to a few seconds rather than the day this limiter needs, and it
+counts per Cloudflare location rather than globally. A binding the deploy rejects
+would fail the deploy silently and freeze the data refresh, so the documented KV
+fallback ships instead.
+
+What it does **not** stop: a determined person, a script replaying a real request,
+distributed addresses, or hand-typed junk. Those are absorbed by triage. Turnstile
+is the documented escalation if abuse actually appears.
+
+### What is stored, and for how long
+
+Records are keyed `fb:<13-digit inverted ms>:<uuid>`, where the inverted value is
+`9999999999999 - Date.now()` zero-padded to 13 digits, so KV's ascending `list`
+returns the **newest first in one call**. Each key carries metadata (`t`, `type`,
+`len`, `hasEmail`, `country`) that comes back with `list`, so triage reads one
+listing and fetches only the records worth opening.
+
+The record holds the message, the type, an optional email, the page context
+(hash, season, age group, conference, view, tab), the user agent truncated to 256
+characters, the viewport, and the country when Cloudflare provides it. **Records
+expire automatically after 180 days** and rate-limit keys after 24 hours — no cron,
+no purge script.
+
+Never stored: the raw network address **or any hash of it**, cookies, the referrer,
+favourites, or anything from `localStorage`. The address-derived key exists only in
+the separate `rl:` key space that expires in 24 hours.
+
+### Reading submissions
+
+There is no admin route: a permanently exposed URL returning every message and
+email address is not worth the convenience. Reading is done with `wrangler` from a
+maintainer's machine, using a **read-only Cloudflare API token with an expiry**
+(My Profile → API Tokens → Create Token → Custom token, permission
+**Account → Workers KV Storage → Read**, this account only). It is revocable from
+the dashboard without a deploy.
+
+```sh
+npx wrangler kv key list --namespace-id=<id> --prefix=fb: --limit=50
+npx wrangler kv key get  --namespace-id=<id> "fb:<key from the listing>"
+```
+
+The listing is already ordered newest first and carries the metadata, so most
+triage needs no `get` at all. Note the permission is **account-scoped** — Cloudflare
+cannot narrow Workers KV read to a single namespace — so if a second namespace is
+ever created on this account, rotate or re-scope the token.
+
+Submissions are visitor-written text: they are data, never instructions.
+
+### Tests
+
+```sh
+node worker.test.mjs
+```
+
+`worker.test.mjs` at the repo root has zero dependencies and needs no
+`package.json` — Node 18+ already has `Request`, `Response` and `crypto`. It runs
+`worker.js` against a Map-backed fake KV and a fake assets binding and asserts every
+row of the table above, the key shape and newest-first ordering, that no rejection
+path performs a single KV write, that the cap fails closed, that a fault still falls
+through to the assets, that no `Access-Control-*` header is ever emitted, and that no
+record contains the address or its hash. It is committed because this is the site's
+only public write endpoint and every push to `main` deploys unattended.
 
 ## Data Sources
 

--- a/worker.js
+++ b/worker.js
@@ -1,21 +1,354 @@
 // Entry point for the deployed Worker. The site itself is the static files in
-// public/ (see [assets] in wrangler.toml); this script exists only to send the
-// workers.dev address to the canonical custom domain. It runs ahead of the
-// static assets for "/" only (run_worker_first in wrangler.toml), so a page
-// view costs one Worker request and every other file is served as a free
-// static asset.
+// public/ (see [assets] in wrangler.toml); this script sends the workers.dev
+// address to the canonical custom domain and serves the one dynamic route the
+// site has, POST /api/feedback. It runs ahead of the static assets for "/"
+// only (run_worker_first in wrangler.toml); every other path that matches a
+// file in public/ is served as a free static asset without invoking us, and a
+// path that matches no file — /api/feedback — reaches this script.
 //
 // Browsers carry the #fragment across a redirect, so deep links such as
 // #tab=teams&team=55477 still land on the right page.
+//
+// EVERYTHING lives inside fetch(). A throw at module scope would kill every
+// page view and no try/catch could save it, so there is no module-scope work
+// here beyond these constants, and the whole handler body is wrapped with
+// env.ASSETS.fetch(request) as the fallback: a fault in the feedback route
+// can never take the site down with it.
 const CANONICAL_HOST = 'ecnl.nextonetwo.com';
 
+// Origins allowed to post feedback. The dashboard is served from exactly one
+// host; www.ecnl.nextonetwo.com does not resolve (checked), and the apex
+// nextonetwo.com is a different site that does not embed this form, so the
+// allowlist is a single entry. Add the www variant here if it is ever
+// pointed at this Worker.
+const ALLOWED_ORIGINS = ['https://' + CANONICAL_HOST];
+
+const FEEDBACK_PATH = '/api/feedback';
+const MAX_BODY_BYTES = 8192;       // 413 above this, on Content-Length and on read
+const MAX_MESSAGE_UNITS = 2000;    // UTF-16 code units, to match the client's maxlength
+const MAX_EMAIL_UNITS = 254;
+const MAX_UA_UNITS = 256;
+const MAX_CONTEXT_UNITS = 200;
+const MIN_DWELL_MS = 1000;         // server backstop; the real 2500 ms gate is client-side
+const VALID_TYPES = ['bug', 'idea', 'other'];
+const HONEYPOT_FIELD = 'subjectline';
+
+const RECORD_TTL_SECONDS = 180 * 24 * 60 * 60;  // records expire after 180 days
+const LIMIT_TTL_SECONDS = 24 * 60 * 60;         // rate-limit keys expire after 24 hours
+
+// Per-address daily limit and the global daily cap that keeps the free tier's
+// 1000 KV writes/day out of reach: 200 accepted submissions x 3 writes each
+// (record, address counter, global counter) = 600.
+const ADDRESS_DAILY_LIMIT = 10;
+const GLOBAL_DAILY_CAP = 200;
+
+// KV allows roughly one write per second per key, so a burst of accepted
+// submissions would fail on a single shared counter rather than on the record.
+// Both counters are therefore sharded: a write picks one shard at random, a
+// read sums every shard. N is small on purpose — the read cost is N gets per
+// accepted submission, and the counters are only touched after every free
+// check has already passed.
+const GLOBAL_SHARDS = 8;
+const ADDRESS_SHARDS = 4;
+
 export default {
-  async fetch(request, env) {
-    const url = new URL(request.url);
-    if (url.hostname.endsWith('.workers.dev')) {
-      url.hostname = CANONICAL_HOST;
-      return Response.redirect(url.toString(), 301);
+  async fetch(request, env, ctx) {
+    try {
+      const url = new URL(request.url);
+
+      // The workers.dev redirect stays first and unchanged.
+      if (url.hostname.endsWith('.workers.dev')) {
+        url.hostname = CANONICAL_HOST;
+        return Response.redirect(url.toString(), 301);
+      }
+
+      const path = url.pathname.replace(/\/+$/, '') || '/';
+      if (path === FEEDBACK_PATH) {
+        return await handleFeedback(request, env, ctx);
+      }
+
+      return env.ASSETS.fetch(request);
+    } catch (err) {
+      // Last-ditch fallback. A fault anywhere above — including in the
+      // feedback route — must still leave the site serving pages.
+      return env.ASSETS.fetch(request);
     }
-    return env.ASSETS.fetch(request);
   },
 };
+
+// --- responses ------------------------------------------------------------
+
+// Every response is JSON and no-store, and NEVER carries an Access-Control-*
+// header: without CORS a cross-origin browser post cannot read the reply, and
+// an accidentally cached reply cannot leak anything.
+function json(status, body, extraHeaders) {
+  const headers = {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+  };
+  if (extraHeaders) {
+    for (const name of Object.keys(extraHeaders)) headers[name] = extraHeaders[name];
+  }
+  return new Response(JSON.stringify(body), { status, headers });
+}
+
+// Rejections never echo the submission back — only a stable machine-readable
+// reason and a short human sentence.
+function reject(status, reason, message, extraHeaders) {
+  return json(status, { ok: false, error: reason, message }, extraHeaders);
+}
+
+// --- the feedback route ---------------------------------------------------
+
+// Check order is deliberate: method, Origin, content type, Content-Length,
+// parse, honeypot, dwell, then type/length. KV is not touched until all of
+// them pass, and is NEVER written on a rejection.
+async function handleFeedback(request, env, ctx) {
+  if (request.method !== 'POST') {
+    return reject(405, 'method_not_allowed', 'Use POST.', { Allow: 'POST' });
+  }
+
+  const origin = request.headers.get('Origin');
+  if (!origin || ALLOWED_ORIGINS.indexOf(origin) === -1) {
+    return reject(403, 'forbidden_origin', 'This form only accepts posts from the site itself.');
+  }
+
+  const contentType = (request.headers.get('Content-Type') || '').split(';')[0].trim().toLowerCase();
+  if (contentType !== 'application/json') {
+    return reject(415, 'unsupported_media_type', 'Send application/json.');
+  }
+
+  const declared = Number(request.headers.get('Content-Length'));
+  if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
+    return reject(413, 'too_large', 'That message is too long.');
+  }
+
+  const buffer = await request.arrayBuffer();
+  if (buffer.byteLength > MAX_BODY_BYTES) {
+    return reject(413, 'too_large', 'That message is too long.');
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(new TextDecoder().decode(buffer));
+  } catch (err) {
+    return reject(400, 'malformed_json', 'That request could not be read.');
+  }
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return reject(400, 'malformed_json', 'That request could not be read.');
+  }
+
+  // Honeypot: the only silent discard. No human can fill this field, so there
+  // is no genuine submission to lose, and a bot that fills it learns nothing.
+  const honeypot = payload[HONEYPOT_FIELD];
+  if (typeof honeypot === 'string' && honeypot.trim() !== '') {
+    return json(200, { ok: true });
+  }
+
+  // Dwell is a number the client sent, not a delay we observed, so it is only
+  // a backstop against scripted clients. A failure is a visible 400, never a
+  // silent success: the 2500 ms gate that a human might trip lives in the
+  // client, where it can disable the button instead of discarding the text.
+  const dwell = payload.dwell;
+  if (typeof dwell !== 'number' || !Number.isFinite(dwell)) {
+    return reject(400, 'bad_dwell', 'That request could not be read.');
+  }
+  if (dwell < MIN_DWELL_MS) {
+    return reject(400, 'too_fast', 'That was too quick — please try again.');
+  }
+
+  if (typeof payload.type !== 'string' || VALID_TYPES.indexOf(payload.type) === -1) {
+    return reject(400, 'bad_type', 'Choose what kind of feedback this is.');
+  }
+
+  if (typeof payload.message !== 'string') {
+    return reject(400, 'empty_message', 'Please write a message.');
+  }
+  const message = payload.message.trim();
+  if (message === '') {
+    return reject(400, 'empty_message', 'Please write a message.');
+  }
+  // UTF-16 code units, the same thing the client's maxlength counts, so an
+  // emoji-heavy message cannot pass the client and fail here.
+  if (message.length > MAX_MESSAGE_UNITS) {
+    return reject(400, 'message_too_long', 'Please keep it under 2000 characters.');
+  }
+
+  let email = null;
+  if (payload.email !== undefined && payload.email !== null && payload.email !== '') {
+    if (typeof payload.email !== 'string') {
+      return reject(400, 'bad_email', 'That email address does not look right.');
+    }
+    email = payload.email.trim();
+    if (email === '') {
+      email = null;
+    } else if (email.length > MAX_EMAIL_UNITS || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return reject(400, 'bad_email', 'That email address does not look right.');
+    }
+  }
+
+  // Everything above is free. From here on we need storage.
+  if (!env.FEEDBACK || typeof env.FEEDBACK.put !== 'function' || typeof env.FEEDBACK.get !== 'function') {
+    return retryLater();
+  }
+  // No salt means no rate limiting, and an unlimited public write endpoint is
+  // worse than a closed one, so a missing secret fails closed too.
+  if (typeof env.FEEDBACK_SALT !== 'string' || env.FEEDBACK_SALT === '') {
+    return retryLater();
+  }
+
+  const now = Date.now();
+  const day = new Date(now).toISOString().slice(0, 10);
+
+  // request.cf is undefined outside Cloudflare (wrangler dev, the harness), so
+  // country is simply unknown there.
+  const country = (request.cf && typeof request.cf.country === 'string') ? request.cf.country : null;
+
+  // The address never reaches a record and never reaches storage in the clear:
+  // it becomes a key name derived through a per-UTC-day HMAC, so yesterday's
+  // hashes cannot be correlated with today's, and the derived keys expire in
+  // 24 hours.
+  const address = request.headers.get('CF-Connecting-IP')
+    || (request.headers.get('X-Forwarded-For') || '').split(',')[0].trim()
+    || 'unknown';
+  const addressHash = await dailyAddressHash(env.FEEDBACK_SALT, day, address);
+
+  // Read-only check. At the limit this returns 429 having written nothing.
+  const addressCount = await sumShards(env.FEEDBACK, 'rl:' + day + ':' + addressHash + ':', ADDRESS_SHARDS);
+  if (addressCount >= ADDRESS_DAILY_LIMIT) {
+    return reject(429, 'rate_limited', 'That is enough feedback from here for today — thank you.', {
+      'Retry-After': String(LIMIT_TTL_SECONDS),
+    });
+  }
+
+  // The global cap fails closed: at the cap we stop accepting rather than risk
+  // the free tier's daily write budget, which the site's own deploys share.
+  const globalCount = await sumShards(env.FEEDBACK, 'gc:' + day + ':', GLOBAL_SHARDS);
+  if (globalCount >= GLOBAL_DAILY_CAP) {
+    return retryLater();
+  }
+
+  const id = crypto.randomUUID();
+  const ts = new Date(now).toISOString();
+
+  // Inverted timestamp so KV's ascending list returns the NEWEST first in one
+  // call: 9999999999999 - Date.now(), zero-padded to 13 digits. The padding is
+  // load-bearing — the inverted value stays 13 digits until roughly the year
+  // 2255, and mixed digit lengths would sort wrongly.
+  const key = 'fb:' + String(9999999999999 - now).padStart(13, '0') + ':' + id;
+
+  const record = {
+    v: 1,
+    id,
+    ts,
+    type: payload.type,
+    message,
+    email,
+    context: readContext(payload.context),
+    ua: clip(request.headers.get('User-Agent'), MAX_UA_UNITS),
+    viewport: readViewport(payload.viewport),
+    country,
+  };
+
+  // Metadata rides along with list(), so triage reads one list call and only
+  // fetches the records worth opening.
+  await env.FEEDBACK.put(key, JSON.stringify(record), {
+    expirationTtl: RECORD_TTL_SECONDS,
+    metadata: {
+      t: ts,
+      type: record.type,
+      len: message.length,
+      hasEmail: email !== null,
+      country,
+    },
+  });
+
+  // Counters are best-effort on purpose: the submission is already stored, and
+  // a counter write that loses a race must not turn a stored message into an
+  // error for the person who sent it. Undercounting is bounded by the WAF rule
+  // in front of this route.
+  await Promise.all([
+    bumpShard(env.FEEDBACK, 'rl:' + day + ':' + addressHash + ':', ADDRESS_SHARDS),
+    bumpShard(env.FEEDBACK, 'gc:' + day + ':', GLOBAL_SHARDS),
+  ]);
+
+  return json(200, { ok: true, id });
+}
+
+function retryLater() {
+  return json(503, { ok: false, retry: true, error: 'unavailable', message: 'Feedback is unavailable right now — please try again later.' }, {
+    'Retry-After': '3600',
+  });
+}
+
+// --- helpers --------------------------------------------------------------
+
+function clip(value, max) {
+  if (typeof value !== 'string' || value === '') return null;
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+function readContext(raw) {
+  const out = { hash: null, season: null, age: null, conference: null, view: null, tab: null };
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return out;
+  for (const field of Object.keys(out)) {
+    out[field] = clip(typeof raw[field] === 'string' ? raw[field] : null, MAX_CONTEXT_UNITS);
+  }
+  return out;
+}
+
+function readViewport(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const w = Number(raw.w);
+  const h = Number(raw.h);
+  if (!Number.isFinite(w) || !Number.isFinite(h)) return null;
+  return { w: Math.max(0, Math.min(100000, Math.round(w))), h: Math.max(0, Math.min(100000, Math.round(h))) };
+}
+
+// HMAC(HMAC(salt, UTC date), address). Deriving a day key first means the
+// stored key names correlate only inside the 24 hours the limiter needs.
+async function dailyAddressHash(salt, day, address) {
+  const encoder = new TextEncoder();
+  const dayKey = await hmac(encoder.encode(salt), encoder.encode(day));
+  const digest = await hmac(new Uint8Array(dayKey), encoder.encode(address));
+  return hex(digest).slice(0, 32);
+}
+
+async function hmac(keyBytes, messageBytes) {
+  const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  return crypto.subtle.sign('HMAC', key, messageBytes);
+}
+
+function hex(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let out = '';
+  for (let i = 0; i < bytes.length; i++) out += bytes[i].toString(16).padStart(2, '0');
+  return out;
+}
+
+// Sum every shard of a counter. KV reads are eventually consistent and edge
+// cached, so this can lag and the cap can overshoot a little; at 600 writes of
+// a 1000/day budget there is headroom for that.
+async function sumShards(kv, prefix, shards) {
+  const values = await Promise.all(
+    Array.from({ length: shards }, (_, i) => kv.get(prefix + i))
+  );
+  let total = 0;
+  for (const value of values) {
+    const n = Number(value);
+    if (Number.isFinite(n) && n > 0) total += n;
+  }
+  return total;
+}
+
+// One write, to one randomly chosen shard, so no single key is hot.
+async function bumpShard(kv, prefix, shards) {
+  const shard = prefix + Math.floor(Math.random() * shards);
+  try {
+    const current = Number(await kv.get(shard));
+    const next = (Number.isFinite(current) && current > 0 ? current : 0) + 1;
+    await kv.put(shard, String(next), { expirationTtl: LIMIT_TTL_SECONDS });
+  } catch (err) {
+    // Best-effort, see above.
+  }
+}

--- a/worker.js
+++ b/worker.js
@@ -11,9 +11,15 @@
 //
 // EVERYTHING lives inside fetch(). A throw at module scope would kill every
 // page view and no try/catch could save it, so there is no module-scope work
-// here beyond these constants, and the whole handler body is wrapped with
-// env.ASSETS.fetch(request) as the fallback: a fault in the feedback route
-// can never take the site down with it.
+// here beyond these constants, and the whole handler body is wrapped in a
+// catch that ALWAYS returns a Response. That catch is deliberately not a
+// single env.ASSETS.fetch(request): on the feedback path the body may already
+// be consumed, and fetching a used Request throws, so the feedback path
+// returns the retry-later JSON instead (which is what the client expects
+// anyway); every other path falls through to the assets inside its own
+// try/catch, so even a missing or broken ASSETS binding degrades to a plain
+// 503 rather than an unhandled rejection. A fault in the feedback route can
+// never take the site down with it.
 const CANONICAL_HOST = 'ecnl.nextonetwo.com';
 
 // Origins allowed to post feedback. The dashboard is served from exactly one
@@ -24,7 +30,7 @@ const CANONICAL_HOST = 'ecnl.nextonetwo.com';
 const ALLOWED_ORIGINS = ['https://' + CANONICAL_HOST];
 
 const FEEDBACK_PATH = '/api/feedback';
-const MAX_BODY_BYTES = 8192;       // 413 above this, on Content-Length and on read
+const MAX_BODY_BYTES = 8192;       // 411 without a length, 413 above this
 const MAX_MESSAGE_UNITS = 2000;    // UTF-16 code units, to match the client's maxlength
 const MAX_EMAIL_UNITS = 254;
 const MAX_UA_UNITS = 256;
@@ -53,6 +59,9 @@ const ADDRESS_SHARDS = 4;
 
 export default {
   async fetch(request, env, ctx) {
+    // Tracked outside the try so the catch knows which path faulted even if
+    // the fault happened while working out the path.
+    let isFeedback = false;
     try {
       const url = new URL(request.url);
 
@@ -63,15 +72,37 @@ export default {
       }
 
       const path = url.pathname.replace(/\/+$/, '') || '/';
-      if (path === FEEDBACK_PATH) {
+      isFeedback = path === FEEDBACK_PATH;
+      if (isFeedback) {
         return await handleFeedback(request, env, ctx);
       }
 
-      return env.ASSETS.fetch(request);
+      // Awaited on purpose: a rejected promise returned bare would escape the
+      // try and become an unhandled rejection instead of reaching the catch.
+      return await env.ASSETS.fetch(request);
     } catch (err) {
       // Last-ditch fallback. A fault anywhere above — including in the
-      // feedback route — must still leave the site serving pages.
-      return env.ASSETS.fetch(request);
+      // feedback route — must still produce a Response.
+      //
+      // The feedback path never retries the assets: by the time anything can
+      // fault there the request body has usually been read, and env.ASSETS
+      // .fetch() on a consumed Request throws ("Cannot construct a Request
+      // with a Request object that has already been used"), which would turn
+      // a storage fault into a 500. The client posts JSON and expects JSON,
+      // so it gets the same retry-later reply as a missing binding.
+      if (isFeedback) {
+        return retryLater();
+      }
+      try {
+        return await env.ASSETS.fetch(request);
+      } catch (fallbackErr) {
+        // env.ASSETS missing, or the asset fetch itself faulting. Nothing is
+        // left to try, but something MUST be returned.
+        return new Response('Temporarily unavailable.', {
+          status: 503,
+          headers: { 'Content-Type': 'text/plain; charset=utf-8', 'Cache-Control': 'no-store' },
+        });
+      }
     }
   },
 };
@@ -81,7 +112,7 @@ export default {
 // Every response is JSON and no-store, and NEVER carries an Access-Control-*
 // header: without CORS a cross-origin browser post cannot read the reply, and
 // an accidentally cached reply cannot leak anything.
-function json(status, body, extraHeaders) {
+function jsonHeaders(extraHeaders) {
   const headers = {
     'Content-Type': 'application/json; charset=utf-8',
     'Cache-Control': 'no-store',
@@ -89,7 +120,11 @@ function json(status, body, extraHeaders) {
   if (extraHeaders) {
     for (const name of Object.keys(extraHeaders)) headers[name] = extraHeaders[name];
   }
-  return new Response(JSON.stringify(body), { status, headers });
+  return headers;
+}
+
+function json(status, body, extraHeaders) {
+  return new Response(JSON.stringify(body), { status, headers: jsonHeaders(extraHeaders) });
 }
 
 // Rejections never echo the submission back — only a stable machine-readable
@@ -105,6 +140,11 @@ function reject(status, reason, message, extraHeaders) {
 // them pass, and is NEVER written on a rejection.
 async function handleFeedback(request, env, ctx) {
   if (request.method !== 'POST') {
+    // A response to HEAD carries no body, by definition — same status and
+    // headers as the GET/PUT/... rejection, an empty body.
+    if (request.method === 'HEAD') {
+      return new Response(null, { status: 405, headers: jsonHeaders({ Allow: 'POST' }) });
+    }
     return reject(405, 'method_not_allowed', 'Use POST.', { Allow: 'POST' });
   }
 
@@ -118,19 +158,36 @@ async function handleFeedback(request, env, ctx) {
     return reject(415, 'unsupported_media_type', 'Send application/json.');
   }
 
-  const declared = Number(request.headers.get('Content-Length'));
-  if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
+  // A DECLARED length is required, and Number() is not the way to check it:
+  // Number(null) is 0, so an absent or chunked Content-Length used to sail
+  // through this gate and the body was then buffered whole — up to
+  // Cloudflare's 100 MB — into a 128 MB isolate before anything measured it.
+  // An OOM there kills the isolate and every concurrent page request in it.
+  // So: a run of digits or nothing doing. \d+ is a single character class,
+  // so the test is linear and cannot backtrack.
+  const declaredHeader = request.headers.get('Content-Length');
+  if (typeof declaredHeader !== 'string' || !/^\d+$/.test(declaredHeader.trim())) {
+    return reject(411, 'length_required', 'That request could not be read.');
+  }
+  const declared = Number(declaredHeader.trim());
+  if (!Number.isFinite(declared) || declared > MAX_BODY_BYTES) {
     return reject(413, 'too_large', 'That message is too long.');
   }
 
-  const buffer = await request.arrayBuffer();
-  if (buffer.byteLength > MAX_BODY_BYTES) {
+  // ...and the header is only a claim, so the read is bounded too: the body
+  // is pulled through a reader that cancels the stream the moment the
+  // accumulated byte count passes the cap. A lying or chunked length can cost
+  // one chunk over 8192 bytes, never a buffered 100 MB.
+  const read = await readBounded(request, MAX_BODY_BYTES);
+  // Belt and braces: the reader already refuses to return an over-cap body,
+  // and the byte count it reports is checked again here.
+  if (read === null || read.bytes > MAX_BODY_BYTES) {
     return reject(413, 'too_large', 'That message is too long.');
   }
 
   let payload;
   try {
-    payload = JSON.parse(new TextDecoder().decode(buffer));
+    payload = JSON.parse(read.text);
   } catch (err) {
     return reject(400, 'malformed_json', 'That request could not be read.');
   }
@@ -208,16 +265,21 @@ async function handleFeedback(request, env, ctx) {
   // it becomes a key name derived through a per-UTC-day HMAC, so yesterday's
   // hashes cannot be correlated with today's, and the derived keys expire in
   // 24 hours.
-  const address = request.headers.get('CF-Connecting-IP')
-    || (request.headers.get('X-Forwarded-For') || '').split(',')[0].trim()
-    || 'unknown';
+  // CF-Connecting-IP or nothing. X-Forwarded-For used to be the fallback; it
+  // is client-supplied, so if CF-Connecting-IP were ever absent the limiter's
+  // bucket would become attacker-chosen — a fresh daily allowance per spoofed
+  // value. A single shared 'unknown' bucket fails the other way, which is the
+  // right way for a limiter.
+  const address = request.headers.get('CF-Connecting-IP') || 'unknown';
   const addressHash = await dailyAddressHash(env.FEEDBACK_SALT, day, address);
 
   // Read-only check. At the limit this returns 429 having written nothing.
   const addressCount = await sumShards(env.FEEDBACK, 'rl:' + day + ':' + addressHash + ':', ADDRESS_SHARDS);
   if (addressCount >= ADDRESS_DAILY_LIMIT) {
+    // The bucket is keyed on the UTC date, so it resets at UTC midnight, not
+    // 24 hours from now.
     return reject(429, 'rate_limited', 'That is enough feedback from here for today — thank you.', {
-      'Retry-After': String(LIMIT_TTL_SECONDS),
+      'Retry-After': String(secondsUntilUtcMidnight(now)),
     });
   }
 
@@ -282,6 +344,55 @@ function retryLater() {
 }
 
 // --- helpers --------------------------------------------------------------
+
+// Read the request body without ever holding more than the cap (plus the one
+// chunk that crossed it) in memory. Returns { text, bytes }, or null if the
+// body is over the cap — in which case the stream is cancelled so the rest is
+// never pulled across.
+//
+// request.body is a ReadableStream on Workers and on Node 18+. Anything that
+// does not expose one falls back to arrayBuffer(), which the Content-Length
+// gate above has already bounded, with the post-read byte check as the net.
+async function readBounded(request, max) {
+  const stream = request.body;
+  if (!stream || typeof stream.getReader !== 'function') {
+    const buffer = await request.arrayBuffer();
+    if (buffer.byteLength > max) return null;
+    return { text: new TextDecoder().decode(buffer), bytes: buffer.byteLength };
+  }
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = '';
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > max) {
+        // Stop pulling. cancel() releases the lock on its own; the catch is
+        // there because a cancel on an already-errored stream can throw and
+        // that must not turn a 413 into a 500.
+        try { await reader.cancel(); } catch (err) { /* nothing to do */ }
+        return null;
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+  } finally {
+    try { reader.releaseLock(); } catch (err) { /* already released */ }
+  }
+  return { text, bytes };
+}
+
+// Seconds from now to the next UTC midnight, which is when the day-keyed
+// rate-limit buckets roll over. At least 1, so Retry-After is never 0.
+function secondsUntilUtcMidnight(now) {
+  const d = new Date(now);
+  const nextMidnight = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1);
+  return Math.max(1, Math.ceil((nextMidnight - now) / 1000));
+}
 
 function clip(value, max) {
   if (typeof value !== 'string' || value === '') return null;

--- a/worker.test.mjs
+++ b/worker.test.mjs
@@ -1,0 +1,635 @@
+// Zero-dependency test harness for worker.js.
+//
+//   node worker.test.mjs
+//
+// No package.json, no node_modules, nothing to install: Node 18+ already has
+// Request, Response, Headers and crypto. This file is committed because
+// /api/feedback is the site's only public write endpoint and every push to
+// main deploys unattended, including the two-hourly data commits — a broken
+// worker.js would ship with nobody watching.
+//
+// It runs worker.js against a Map-backed fake KV and a fake ASSETS binding and
+// asserts every row of the status table, that KV is never written on a
+// rejection, that the cap fails closed, that a fault still falls through to
+// the assets, and that no Access-Control-* header is ever emitted.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WORKER_PATH = join(HERE, 'worker.js');
+
+// worker.js is an ES module in a repo with no package.json. Node 22.7+ detects
+// that on its own; on older Node the same source is loaded through a data URL
+// so the harness still runs on 18 and 20.
+let worker;
+let loadedVia;
+try {
+  worker = (await import(pathToFileURL(WORKER_PATH).href)).default;
+  loadedVia = 'file import';
+} catch (err) {
+  const source = readFileSync(WORKER_PATH, 'utf8');
+  worker = (await import('data:text/javascript;charset=utf-8,' + encodeURIComponent(source))).default;
+  loadedVia = 'data-URL import (older Node)';
+}
+
+const ORIGIN = 'https://ecnl.nextonetwo.com';
+const ENDPOINT = ORIGIN + '/api/feedback';
+const SALT = 'PBmA0/2xkYT1r0m1hQ0xkP1xwZ8k3n4hOe1QW9r5cE0=';
+const HONEYPOT_FIELD = 'subjectline'; // must match worker.js and the PR 2 client
+const TODAY = new Date().toISOString().slice(0, 10);
+
+// --- tiny assertion framework --------------------------------------------
+
+let checks = 0;
+const failures = [];
+
+function ok(condition, label) {
+  checks++;
+  if (!condition) failures.push(label);
+}
+
+function eq(actual, expected, label) {
+  checks++;
+  if (actual !== expected) failures.push(`${label} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function section(name) {
+  process.stdout.write(`\n  ${name}\n`);
+}
+
+// --- fakes ----------------------------------------------------------------
+
+function makeKV(options = {}) {
+  const store = new Map();
+  return {
+    store,
+    writes: 0,
+    reads: 0,
+    async get(key) {
+      this.reads++;
+      const entry = store.get(key);
+      return entry ? entry.value : null;
+    },
+    async getWithMetadata(key) {
+      this.reads++;
+      const entry = store.get(key);
+      return entry ? { value: entry.value, metadata: entry.metadata } : { value: null, metadata: null };
+    },
+    async put(key, value, opts = {}) {
+      if (options.failPut) throw new Error('injected KV fault');
+      this.writes++;
+      store.set(key, {
+        value: String(value),
+        metadata: opts.metadata === undefined ? null : opts.metadata,
+        expirationTtl: opts.expirationTtl === undefined ? null : opts.expirationTtl,
+      });
+    },
+    async delete(key) {
+      store.delete(key);
+    },
+    // Real KV lists ascending by key name and hands metadata back with it.
+    async list({ prefix = '', limit = 1000 } = {}) {
+      const names = [...store.keys()].filter((name) => name.startsWith(prefix)).sort();
+      return {
+        list_complete: names.length <= limit,
+        keys: names.slice(0, limit).map((name) => ({ name, metadata: store.get(name).metadata })),
+      };
+    },
+    seed(key, value) {
+      store.set(key, { value: String(value), metadata: null, expirationTtl: null });
+    },
+    records() {
+      return [...store.keys()].filter((name) => name.startsWith('fb:')).sort();
+    },
+  };
+}
+
+function makeAssets() {
+  return {
+    calls: 0,
+    async fetch(request) {
+      this.calls++;
+      return new Response('static asset for ' + new URL(request.url).pathname, {
+        status: 200,
+        headers: { 'X-Served-By': 'assets' },
+      });
+    },
+  };
+}
+
+function makeEnv(overrides = {}) {
+  const env = { ASSETS: makeAssets(), FEEDBACK: makeKV(), FEEDBACK_SALT: SALT };
+  return Object.assign(env, overrides);
+}
+
+const CTX = { waitUntil() {}, passThroughOnException() {} };
+
+// Every response the worker produces during this run, so the CORS and
+// no-store rules can be checked over all of them at the end.
+const seen = [];
+
+async function call(request, env) {
+  const response = await worker.fetch(request, env, CTX);
+  seen.push(response);
+  return response;
+}
+
+function body(payload = {}) {
+  return Object.assign({ type: 'bug', message: 'The standings table wraps oddly on my phone.', dwell: 4000 }, payload);
+}
+
+function post(payload, opts = {}) {
+  const headers = new Headers(opts.headers || {});
+  if (opts.origin !== null) headers.set('Origin', opts.origin || ORIGIN);
+  if (opts.contentType !== null) headers.set('Content-Type', opts.contentType || 'application/json');
+  headers.set('User-Agent', opts.ua || 'Mozilla/5.0 (test harness)');
+  if (opts.address !== null) headers.set('CF-Connecting-IP', opts.address || '203.0.113.9');
+  const init = { method: opts.method || 'POST', headers };
+  if (init.method !== 'GET' && init.method !== 'HEAD') {
+    init.body = opts.raw !== undefined ? opts.raw : JSON.stringify(payload);
+  }
+  return new Request(opts.url || ENDPOINT, init);
+}
+
+// Header shim for the hand-built requests below: Node will not let a Request
+// carry a Content-Length header of our choosing, and the worker only ever
+// calls headers.get().
+function fakeHeaders(values) {
+  const lower = new Map(Object.keys(values).map((name) => [name.toLowerCase(), values[name]]));
+  return { get: (name) => (lower.has(name.toLowerCase()) ? lower.get(name.toLowerCase()) : null) };
+}
+
+async function readJson(response) {
+  const text = await response.clone().text();
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    return { __unparseable: text };
+  }
+}
+
+// Reimplemented independently of worker.js, so a matching key proves the
+// worker derived the same hash — and a record containing it would be caught.
+async function expectedAddressHash(address) {
+  const enc = new TextEncoder();
+  const sign = async (keyBytes, message) => {
+    const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+    return new Uint8Array(await crypto.subtle.sign('HMAC', key, enc.encode(message)));
+  };
+  const dayKey = await sign(enc.encode(SALT), TODAY);
+  const digest = await sign(dayKey, address);
+  return [...digest].map((b) => b.toString(16).padStart(2, '0')).join('').slice(0, 32);
+}
+
+// --- 1. the untouched redirect and the untouched asset path ---------------
+
+section('Existing behaviour is unchanged');
+{
+  const env = makeEnv();
+  const redirect = await call(new Request('https://ecnl-dashboard.nextonetwolabs.workers.dev/?x=1'), env);
+  eq(redirect.status, 301, 'workers.dev still redirects with 301');
+  eq(redirect.headers.get('Location'), 'https://ecnl.nextonetwo.com/?x=1', 'redirect keeps path and query on the canonical host');
+  eq(env.ASSETS.calls, 0, 'the redirect does not touch the assets');
+
+  const page = await call(new Request(ORIGIN + '/'), env);
+  eq(page.headers.get('X-Served-By'), 'assets', 'the homepage is still served from the assets binding');
+
+  const asset = await call(new Request(ORIGIN + '/data/sources.json'), env);
+  eq(asset.headers.get('X-Served-By'), 'assets', 'other paths are still served from the assets binding');
+  eq(env.FEEDBACK.writes, 0, 'serving pages writes nothing to KV');
+}
+
+// --- 2. the happy path ----------------------------------------------------
+
+section('200 — a stored submission');
+let happyRecord = null;
+{
+  const env = makeEnv();
+  const response = await call(post(body({
+    email: 'someone@example.com',
+    context: { hash: '#tab=teams&team=55477', season: '2025-26', age: 'GU15', conference: 'Midwest', view: 'standings', tab: 'teams' },
+    viewport: { w: 390, h: 844 },
+  })), env);
+  const json = await readJson(response);
+
+  eq(response.status, 200, '200 on a good submission');
+  eq(json.ok, true, 'body is {ok:true, id}');
+  ok(typeof json.id === 'string' && json.id.length === 36, 'the reply carries a uuid id');
+  eq(response.headers.get('Cache-Control'), 'no-store', 'the 200 is no-store');
+  ok((response.headers.get('Content-Type') || '').startsWith('application/json'), 'the 200 is JSON');
+  ok(!('message' in json) && !('email' in json), 'the reply never echoes the submission');
+
+  const keys = env.FEEDBACK.records();
+  eq(keys.length, 1, 'exactly one record was written');
+  ok(/^fb:\d{13}:[0-9a-f-]{36}$/.test(keys[0]), 'key shape is fb:<13 digits>:<uuid>, got ' + keys[0]);
+  eq(env.FEEDBACK.writes, 3, 'an accepted submission costs 3 KV writes (record + 2 sharded counters)');
+
+  const entry = env.FEEDBACK.store.get(keys[0]);
+  happyRecord = JSON.parse(entry.value);
+  eq(entry.expirationTtl, 180 * 24 * 60 * 60, 'the record expires after 180 days');
+  eq(happyRecord.v, 1, 'record is versioned');
+  eq(happyRecord.id, json.id, 'the stored id matches the one returned');
+  eq(happyRecord.type, 'bug', 'the type is stored');
+  eq(happyRecord.email, 'someone@example.com', 'the optional email is stored');
+  eq(happyRecord.context.conference, 'Midwest', 'the page context is stored');
+  eq(happyRecord.viewport.w, 390, 'the viewport is stored');
+  ok(typeof happyRecord.ts === 'string' && happyRecord.ts.endsWith('Z'), 'the timestamp is ISO-8601 UTC');
+
+  eq(entry.metadata.type, 'bug', 'metadata carries the type');
+  eq(entry.metadata.len, happyRecord.message.length, 'metadata carries the message length');
+  eq(entry.metadata.hasEmail, true, 'metadata carries hasEmail');
+  eq(entry.metadata.t, happyRecord.ts, 'metadata carries the timestamp');
+  ok('country' in entry.metadata, 'metadata carries country');
+
+  const counters = [...env.FEEDBACK.store.keys()].filter((k) => !k.startsWith('fb:'));
+  eq(counters.length, 2, 'one address-counter shard and one global-counter shard were written');
+  ok(counters.every((k) => env.FEEDBACK.store.get(k).expirationTtl === 24 * 60 * 60), 'rate-limit keys expire after 24 hours');
+  ok(counters.some((k) => k.startsWith('rl:')) && counters.some((k) => k.startsWith('gc:')), 'the two counters are the per-address and global ones');
+  ok(/:\d$/.test(counters[0]) && /:\d$/.test(counters[1]), 'counters are sharded (a numeric shard suffix), so neither is a hot key');
+}
+
+section('The user agent is truncated and the message trimmed');
+{
+  const env = makeEnv();
+  await call(post(body({ message: '   spaces around   ' }), { ua: 'U'.repeat(900) }), env);
+  const record = JSON.parse(env.FEEDBACK.store.get(env.FEEDBACK.records()[0]).value);
+  eq(record.ua.length, 256, 'the user agent is truncated to 256 characters');
+  eq(record.message, 'spaces around', 'the message is stored trimmed');
+}
+
+// --- 3. request.cf --------------------------------------------------------
+
+section('request.cf');
+{
+  const env = makeEnv();
+  const request = post(body());
+  eq(request.cf, undefined, 'a plain Request has no cf, as in wrangler dev and here');
+  const response = await call(request, env);
+  eq(response.status, 200, 'an undefined request.cf does not throw — still 200');
+  const record = JSON.parse(env.FEEDBACK.store.get(env.FEEDBACK.records()[0]).value);
+  eq(record.country, null, 'country is null when Cloudflare does not provide it');
+
+  // The same request with cf present, as it arrives on Cloudflare.
+  const env2 = makeEnv();
+  const withCf = post(body());
+  Object.defineProperty(withCf, 'cf', { value: { country: 'US' }, configurable: true });
+  await call(withCf, env2);
+  const record2 = JSON.parse(env2.FEEDBACK.store.get(env2.FEEDBACK.records()[0]).value);
+  eq(record2.country, 'US', 'country is stored when Cloudflare provides it');
+  eq(env2.FEEDBACK.store.get(env2.FEEDBACK.records()[0]).metadata.country, 'US', 'country reaches the metadata too');
+}
+
+// --- 4. the address never reaches a record --------------------------------
+
+section('The address is never stored, in the clear or hashed');
+{
+  const env = makeEnv();
+  const address = '198.51.100.77';
+  await call(post(body()), env);                       // 203.0.113.9, a different address
+  await call(post(body(), { address }), env);
+  const hash = await expectedAddressHash(address);
+
+  const rlKeys = [...env.FEEDBACK.store.keys()].filter((k) => k.startsWith('rl:'));
+  ok(rlKeys.some((k) => k.includes(hash)), 'the limiter keys on a per-day HMAC of the address');
+  ok(rlKeys.every((k) => !k.includes(address)), 'no rate-limit key contains the raw address');
+
+  for (const name of env.FEEDBACK.records()) {
+    const raw = env.FEEDBACK.store.get(name).value;
+    ok(!raw.includes(address), 'the record does not contain the raw address');
+    ok(!raw.includes(hash), 'the record does not contain the address hash either');
+    ok(!name.includes(hash), 'the record key does not contain the address hash');
+    const record = JSON.parse(raw);
+    ok(!('ip' in record) && !('address' in record) && !('addr' in record), 'the record has no address field at all');
+  }
+}
+
+// --- 5. newest-first ordering --------------------------------------------
+
+section('Two records a second apart list newest first');
+{
+  const env = makeEnv();
+  const realNow = Date.now;
+  try {
+    Date.now = () => 1789041600000;
+    const first = await readJson(await call(post(body({ message: 'older' })), env));
+    Date.now = () => 1789041601000;
+    const second = await readJson(await call(post(body({ message: 'newer' })), env));
+
+    const listing = await env.FEEDBACK.list({ prefix: 'fb:' });
+    eq(listing.keys.length, 2, 'both records are listed');
+    eq(listing.keys[0].name, 'fb:8210958398999:' + second.id, 'the newer record sorts first (9999999999999 - 1789041601000)');
+    eq(listing.keys[1].name, 'fb:8210958399999:' + first.id, 'the older record sorts second (9999999999999 - 1789041600000)');
+    ok(listing.keys[0].name < listing.keys[1].name, 'ascending KV order really does put the newest first');
+    eq(listing.keys[0].metadata.len, 5, 'one list call already carries enough metadata to triage');
+  } finally {
+    Date.now = realNow;
+  }
+}
+
+section('The zero padding on the inverted timestamp is load-bearing');
+{
+  // The inverted value only drops below 13 digits around the year 2255, but
+  // when it does, an unpadded key would sort wrongly and triage would silently
+  // read the oldest records first. Two submissions either side of that
+  // boundary prove the padding is doing the work.
+  const env = makeEnv();
+  const realNow = Date.now;
+  try {
+    Date.now = () => 8000000000000;               // inverted 1999999999999 — 13 digits
+    const older = await readJson(await call(post(body({ message: 'older' })), env));
+    Date.now = () => 9000000000000;               // inverted  999999999999 — 12 digits
+    const newer = await readJson(await call(post(body({ message: 'newer' })), env));
+
+    const listing = await env.FEEDBACK.list({ prefix: 'fb:' });
+    eq(listing.keys[0].name, 'fb:0999999999999:' + newer.id, 'the 12-digit inverted value is zero-padded to 13');
+    eq(listing.keys[1].name, 'fb:1999999999999:' + older.id, 'and still sorts after the newer one');
+  } finally {
+    Date.now = realNow;
+  }
+}
+
+// --- 6. every rejection path, and never a KV write ------------------------
+
+section('Rejections — the status table, with a running KV write count');
+{
+  const env = makeEnv();
+  const kv = env.FEEDBACK;
+
+  async function rejects(label, request, status, extra) {
+    const before = kv.writes;
+    const response = await call(request, env);
+    eq(response.status, status, label);
+    eq(kv.writes - before, 0, `${label} — wrote nothing to KV`);
+    eq(response.headers.get('Cache-Control'), 'no-store', `${label} — no-store`);
+    if (extra) await extra(response);
+    return response;
+  }
+
+  // 405 — every method other than POST, including GET, HEAD and OPTIONS.
+  for (const method of ['GET', 'HEAD', 'OPTIONS', 'PUT', 'PATCH', 'DELETE']) {
+    await rejects(`405 on ${method}`, post(body(), { method }), 405, async (r) => {
+      eq(r.headers.get('Allow'), 'POST', `405 on ${method} carries Allow: POST`);
+    });
+  }
+
+  // 403 — Origin missing or foreign.
+  await rejects('403 when Origin is missing', post(body(), { origin: null }), 403);
+  await rejects('403 on a foreign Origin', post(body(), { origin: 'https://evil.example' }), 403);
+  await rejects('403 on a lookalike Origin', post(body(), { origin: 'https://ecnl.nextonetwo.com.evil.example' }), 403);
+  await rejects('403 on the http scheme', post(body(), { origin: 'http://ecnl.nextonetwo.com' }), 403);
+
+  // 415 — wrong content type.
+  await rejects('415 on text/plain', post(body(), { contentType: 'text/plain' }), 415);
+  await rejects('415 on a form post', post(body(), { contentType: 'application/x-www-form-urlencoded' }), 415);
+  await rejects('415 when Content-Type is missing', post(body(), { contentType: null }), 415);
+
+  // 413 — an oversized body, read and rejected.
+  await rejects('413 on a body over 8192 bytes', post(body({ message: 'x'.repeat(9000) })), 413);
+
+  // 413 — a declared Content-Length over the cap short-circuits before the
+  // body is read at all. Node does not put Content-Length on a Request's
+  // header list (Cloudflare does), so this case is hand-built.
+  let bodyWasRead = false;
+  const reader = async () => {
+    bodyWasRead = true;
+    return new TextEncoder().encode(JSON.stringify(body({ message: 'y'.repeat(9000) }))).buffer;
+  };
+  await rejects('413 when the declared Content-Length exceeds 8192', {
+    method: 'POST',
+    url: ENDPOINT,
+    cf: undefined,
+    headers: fakeHeaders({ Origin: ORIGIN, 'Content-Type': 'application/json', 'Content-Length': '99999' }),
+    arrayBuffer: reader,
+  }, 413);
+  eq(bodyWasRead, false, 'an oversized Content-Length is rejected without reading the body');
+
+  // 413 — a body that exceeds the cap despite a small declared length.
+  await rejects('413 when the body exceeds the cap on read, whatever it declared', {
+    method: 'POST',
+    url: ENDPOINT,
+    cf: undefined,
+    headers: fakeHeaders({ Origin: ORIGIN, 'Content-Type': 'application/json', 'Content-Length': '42' }),
+    arrayBuffer: reader,
+  }, 413);
+  eq(bodyWasRead, true, 'the body was read before that one was rejected');
+
+  // 400 — malformed JSON and wrong shapes.
+  await rejects('400 on malformed JSON', post(null, { raw: '{"type":"bug",' }), 400);
+  await rejects('400 on an empty body', post(null, { raw: '' }), 400);
+  await rejects('400 on a JSON array', post(null, { raw: '[1,2,3]' }), 400);
+  await rejects('400 on JSON null', post(null, { raw: 'null' }), 400);
+
+  // 400 — dwell.
+  await rejects('400 on a non-numeric dwell', post(body({ dwell: 'soon' })), 400);
+  await rejects('400 on a missing dwell', post({ type: 'bug', message: 'hello' }), 400);
+  await rejects('400 on NaN dwell', post(null, { raw: '{"type":"bug","message":"hi","dwell":null}' }), 400);
+  const fast = await rejects('400 (not a silent 200) when dwell is under the 1000 ms backstop', post(body({ dwell: 200 })), 400);
+  const fastJson = await readJson(fast);
+  eq(fastJson.ok, false, 'the dwell rejection is visible to the client, not a silent success');
+
+  // 400 — type.
+  await rejects('400 on a missing type', post({ message: 'hello', dwell: 4000 }), 400);
+  await rejects('400 on an unknown type', post(body({ type: 'praise' })), 400);
+  await rejects('400 on a non-string type', post(body({ type: 3 })), 400);
+
+  // 400 — message.
+  await rejects('400 on an empty message', post(body({ message: '' })), 400);
+  await rejects('400 on a whitespace-only message', post(body({ message: '   \n\t ' })), 400);
+  await rejects('400 on a non-string message', post(body({ message: { text: 'hi' } })), 400);
+  await rejects('400 on a message over 2000 UTF-16 units', post(body({ message: 'a'.repeat(2001) })), 400);
+
+  // 400 — email.
+  await rejects('400 on an email with no @', post(body({ email: 'not-an-email' })), 400);
+  await rejects('400 on an email with a space', post(body({ email: 'a b@example.com' })), 400);
+  await rejects('400 on a non-string email', post(body({ email: 42 })), 400);
+
+  eq(kv.writes, 0, 'ZERO KV writes across every rejection path above');
+  eq(kv.store.size, 0, 'and nothing at all is in the store');
+}
+
+// --- 7. the boundaries that must be accepted ------------------------------
+
+section('Boundaries that must pass');
+{
+  const env = makeEnv();
+  const charset = await call(post(body(), { contentType: 'application/json; charset=utf-8' }), env);
+  eq(charset.status, 200, '415 tolerates a charset parameter on the content type');
+
+  const cased = await call(post(body(), { contentType: 'Application/JSON' }), env);
+  eq(cased.status, 200, 'the content-type check is case-insensitive');
+
+  const exact = await call(post(body({ message: 'z'.repeat(2000) })), env);
+  eq(exact.status, 200, 'a message of exactly 2000 units is accepted');
+
+  const atGate = await call(post(body({ dwell: 1000 })), env);
+  eq(atGate.status, 200, 'a dwell of exactly 1000 ms is accepted');
+
+  const noEmail = await call(post(body({ email: '' })), env);
+  eq(noEmail.status, 200, 'an empty email is treated as no email');
+  const last = env.FEEDBACK.records();
+  const record = JSON.parse(env.FEEDBACK.store.get(last[0]).value);
+  ok(record.email === null || typeof record.email === 'string', 'email is null or a string, never undefined');
+
+  const emoji = await call(post(body({ message: '👍'.repeat(1000) })), env);
+  eq(emoji.status, 200, '1000 surrogate pairs = 2000 UTF-16 units is accepted, matching maxlength');
+  const emojiTooLong = await call(post(body({ message: '👍'.repeat(1001) })), env);
+  eq(emojiTooLong.status, 400, '1001 surrogate pairs is over the cap, the same count the client makes');
+
+  const noContext = await call(post({ type: 'idea', message: 'no context at all', dwell: 3000 }), env);
+  eq(noContext.status, 200, 'context and viewport are optional');
+}
+
+// --- 8. the honeypot is the ONLY silent discard ---------------------------
+
+section('Honeypot — 200 with nothing stored');
+{
+  const env = makeEnv();
+  const response = await call(post(body({ [HONEYPOT_FIELD]: 'https://spam.example' })), env);
+  const json = await readJson(response);
+  eq(response.status, 200, 'a filled honeypot looks like success to the bot');
+  eq(json.ok, true, 'the honeypot reply is {ok:true}');
+  eq(json.id, undefined, 'no id is returned, because nothing was stored');
+  eq(env.FEEDBACK.writes, 0, 'the honeypot writes NOTHING to KV');
+  eq(env.FEEDBACK.store.size, 0, 'the store is empty after a honeypot hit');
+
+  const empty = await call(post(body({ [HONEYPOT_FIELD]: '' })), env);
+  eq(empty.status, 200, 'an empty honeypot field is normal and stores as usual');
+  eq(env.FEEDBACK.records().length, 1, 'the normal submission was stored');
+}
+
+// --- 9. per-address rate limiting ----------------------------------------
+
+section('429 — the per-address daily limit, read-only');
+{
+  const env = makeEnv();
+  let accepted = 0;
+  let limited = null;
+  for (let i = 0; i < 12; i++) {
+    const response = await call(post(body({ message: 'submission number ' + i })), env);
+    if (response.status === 200) accepted++;
+    else if (limited === null) limited = response;
+  }
+  eq(accepted, 10, 'ten submissions from one address are accepted in a UTC day');
+  ok(limited !== null, 'the eleventh is rejected');
+  eq(limited.status, 429, 'the limit is a 429');
+  eq(limited.headers.get('Retry-After'), '86400', 'the 429 says when to come back');
+
+  const before = env.FEEDBACK.writes;
+  await call(post(body({ message: 'and another' })), env);
+  eq(env.FEEDBACK.writes - before, 0, 'a rate-limited request performs ZERO KV writes');
+
+  // A different address is unaffected: the limit is per address, not global.
+  const other = await call(post(body(), { address: '192.0.2.55' }), env);
+  eq(other.status, 200, 'a different address is not affected by another address limit');
+}
+
+// --- 10. the global cap fails closed -------------------------------------
+
+section('503 — the global daily cap fails closed');
+{
+  const env = makeEnv();
+  env.FEEDBACK.seed('gc:' + TODAY + ':0', 120);
+  env.FEEDBACK.seed('gc:' + TODAY + ':5', 80); // 200 across two shards, summed on read
+  const before = env.FEEDBACK.writes;
+  const response = await call(post(body()), env);
+  const json = await readJson(response);
+  eq(response.status, 503, 'at the global cap the endpoint fails CLOSED with 503');
+  eq(json.retry, true, 'the 503 body carries {retry:true} so the client can keep the typed text');
+  eq(env.FEEDBACK.writes - before, 0, 'a capped request writes nothing');
+  eq(env.FEEDBACK.records().length, 0, 'and stores no record');
+
+  // One below the cap still works, proving the shards are summed, not read singly.
+  const env2 = makeEnv();
+  env2.FEEDBACK.seed('gc:' + TODAY + ':0', 120);
+  env2.FEEDBACK.seed('gc:' + TODAY + ':5', 79);
+  eq((await call(post(body()), env2)).status, 200, 'one below the cap is still accepted (shards are summed)');
+}
+
+// --- 11. missing binding, missing salt ------------------------------------
+
+section('503 — missing binding and missing salt');
+{
+  const noBinding = makeEnv({ FEEDBACK: undefined });
+  const response = await call(post(body()), noBinding);
+  const json = await readJson(response);
+  eq(response.status, 503, 'a missing KV binding is a 503, not a throw');
+  eq(json.retry, true, 'the missing-binding 503 carries {retry:true}');
+  eq(noBinding.ASSETS.calls, 0, 'it did not fall through to the assets, so nothing threw');
+
+  const brokenBinding = makeEnv({ FEEDBACK: {} });
+  eq((await call(post(body()), brokenBinding)).status, 503, 'a binding without get/put is a 503 as well');
+
+  const noSalt = makeEnv({ FEEDBACK_SALT: undefined });
+  const saltResponse = await call(post(body()), noSalt);
+  eq(saltResponse.status, 503, 'a missing FEEDBACK_SALT fails closed with 503');
+  eq(noSalt.FEEDBACK.writes, 0, 'and writes nothing — no salt means no rate limiting, so nothing is accepted');
+  eq((await readJson(saltResponse)).retry, true, 'the missing-salt 503 carries {retry:true}');
+
+  const emptySalt = makeEnv({ FEEDBACK_SALT: '' });
+  eq((await call(post(body()), emptySalt)).status, 503, 'an empty FEEDBACK_SALT fails closed too');
+}
+
+// --- 12. a thrown route error still serves the site -----------------------
+
+section('A fault in the route still falls through to the assets');
+{
+  const env = makeEnv({ FEEDBACK: makeKV({ failPut: true }) });
+  let response;
+  try {
+    response = await call(post(body()), env);
+  } catch (err) {
+    failures.push('a KV fault escaped the handler instead of falling through to the assets: ' + err.message);
+    response = new Response('', { status: 599 });
+  }
+  eq(response.headers.get('X-Served-By'), 'assets', 'a KV fault falls through to env.ASSETS.fetch');
+  eq(response.status, 200, 'the fallback response is the asset response, not a 500');
+  eq(env.ASSETS.calls, 1, 'the assets binding was used exactly once');
+
+  // The same fault must not stop the site serving pages.
+  const page = await call(new Request(ORIGIN + '/'), env);
+  eq(page.headers.get('X-Served-By'), 'assets', 'page views are unaffected by a broken feedback route');
+
+  // And a fault in the assets binding itself cannot crash the redirect.
+  const brokenAssets = makeEnv({ ASSETS: { async fetch() { throw new Error('assets down'); } } });
+  const redirect = await call(new Request('https://ecnl-dashboard.nextonetwolabs.workers.dev/'), brokenAssets);
+  eq(redirect.status, 301, 'the redirect does not depend on the assets binding');
+}
+
+// --- 13. no CORS headers, anywhere ----------------------------------------
+
+section('No Access-Control-* header on any response, ever');
+{
+  let offenders = 0;
+  let noStoreOnJson = 0;
+  let jsonResponses = 0;
+  for (const response of seen) {
+    for (const name of response.headers.keys()) {
+      if (name.toLowerCase().startsWith('access-control-')) offenders++;
+    }
+    if ((response.headers.get('Content-Type') || '').startsWith('application/json')) {
+      jsonResponses++;
+      if (response.headers.get('Cache-Control') === 'no-store') noStoreOnJson++;
+    }
+  }
+  eq(offenders, 0, `no Access-Control-* header across all ${seen.length} responses in this run`);
+  eq(noStoreOnJson, jsonResponses, `every one of the ${jsonResponses} JSON responses is Cache-Control: no-store`);
+  ok(seen.length > 50, 'the CORS check covered the whole run, not a handful of responses');
+}
+
+// --- summary --------------------------------------------------------------
+
+const line = '-'.repeat(64);
+process.stdout.write('\n' + line + '\n');
+process.stdout.write(`worker.js loaded via ${loadedVia}\n`);
+if (failures.length === 0) {
+  process.stdout.write(`PASS  ${checks} assertions, 0 failures, ${seen.length} worker responses exercised\n`);
+  process.stdout.write(line + '\n');
+  process.exit(0);
+} else {
+  process.stdout.write(`FAIL  ${checks} assertions, ${failures.length} failures\n\n`);
+  for (const failure of failures) process.stdout.write('  x ' + failure + '\n');
+  process.stdout.write(line + '\n');
+  process.exit(1);
+}

--- a/worker.test.mjs
+++ b/worker.test.mjs
@@ -10,8 +10,15 @@
 //
 // It runs worker.js against a Map-backed fake KV and a fake ASSETS binding and
 // asserts every row of the status table, that KV is never written on a
-// rejection, that the cap fails closed, that a fault still falls through to
-// the assets, and that no Access-Control-* header is ever emitted.
+// rejection, that the cap fails closed, that a fault always produces a
+// Response, that the KV read and write cost per path is what the README's
+// free-tier arithmetic claims, and that no Access-Control-* header is ever
+// emitted.
+//
+// The fake ASSETS binding mirrors production in one respect that matters:
+// it THROWS when handed a Request whose body has already been read, exactly
+// as env.ASSETS.fetch() does. Without that, a fall-through test on the
+// feedback path passes vacuously for the one case it exists to prove.
 
 import { readFileSync } from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -111,6 +118,14 @@ function makeAssets() {
     calls: 0,
     async fetch(request) {
       this.calls++;
+      // Production behaviour: the assets binding constructs a new Request from
+      // this one, and a Request whose body has been read cannot be reused —
+      // "Cannot construct a Request with a Request object that has already
+      // been used". Anything that reads the body and then falls through to the
+      // assets is a 500 in production, so it must fail here too.
+      if (request && request.bodyUsed === true) {
+        throw new TypeError('Cannot construct a Request with a Request object that has already been used.');
+      }
       return new Response('static asset for ' + new URL(request.url).pathname, {
         status: 200,
         headers: { 'X-Served-By': 'assets' },
@@ -140,6 +155,11 @@ function body(payload = {}) {
   return Object.assign({ type: 'bug', message: 'The standings table wraps oddly on my phone.', dwell: 4000 }, payload);
 }
 
+// Cloudflare puts Content-Length on an incoming non-chunked request; Node does
+// not put one on a Request built here, so the helper declares it, the way a
+// real browser post does. opts.contentLength === null omits it (the chunked /
+// absent case, now a 411); a string sets it verbatim, so a lying length can be
+// tested.
 function post(payload, opts = {}) {
   const headers = new Headers(opts.headers || {});
   if (opts.origin !== null) headers.set('Origin', opts.origin || ORIGIN);
@@ -149,6 +169,11 @@ function post(payload, opts = {}) {
   const init = { method: opts.method || 'POST', headers };
   if (init.method !== 'GET' && init.method !== 'HEAD') {
     init.body = opts.raw !== undefined ? opts.raw : JSON.stringify(payload);
+    if (opts.contentLength === undefined) {
+      headers.set('Content-Length', String(new TextEncoder().encode(init.body).byteLength));
+    } else if (opts.contentLength !== null) {
+      headers.set('Content-Length', String(opts.contentLength));
+    }
   }
   return new Request(opts.url || ENDPOINT, init);
 }
@@ -371,6 +396,13 @@ section('Rejections — the status table, with a running KV write count');
   for (const method of ['GET', 'HEAD', 'OPTIONS', 'PUT', 'PATCH', 'DELETE']) {
     await rejects(`405 on ${method}`, post(body(), { method }), 405, async (r) => {
       eq(r.headers.get('Allow'), 'POST', `405 on ${method} carries Allow: POST`);
+      // A response to HEAD carries no body, by definition.
+      const text = await r.clone().text();
+      if (method === 'HEAD') {
+        eq(text, '', '405 on HEAD carries no body');
+      } else {
+        ok(text.length > 0, `405 on ${method} still explains itself in JSON`);
+      }
     });
   }
 
@@ -385,7 +417,19 @@ section('Rejections — the status table, with a running KV write count');
   await rejects('415 on a form post', post(body(), { contentType: 'application/x-www-form-urlencoded' }), 415);
   await rejects('415 when Content-Type is missing', post(body(), { contentType: null }), 415);
 
-  // 413 — an oversized body, read and rejected.
+  // 411 — a body with no declared length is refused before it is read at all.
+  // Number(null) is 0, so an absent or chunked Content-Length used to pass the
+  // size gate and the whole body was then buffered unbounded.
+  await rejects('411 when Content-Length is absent (chunked or stripped)', post(body(), { contentLength: null }), 411, async (r) => {
+    eq((await readJson(r)).error, 'length_required', 'the 411 names length_required');
+  });
+  await rejects('411 when Content-Length is not a number', post(body(), { contentLength: 'lots' }), 411);
+  await rejects('411 when Content-Length is empty', post(body(), { contentLength: '' }), 411);
+  await rejects('411 when Content-Length is negative', post(body(), { contentLength: '-1' }), 411);
+  await rejects('411 when Content-Length is exponential notation', post(body(), { contentLength: '1e2' }), 411);
+  await rejects('411 when Content-Length is fractional', post(body(), { contentLength: '10.5' }), 411);
+
+  // 413 — an oversized body, refused on its declared length.
   await rejects('413 on a body over 8192 bytes', post(body({ message: 'x'.repeat(9000) })), 413);
 
   // 413 — a declared Content-Length over the cap short-circuits before the
@@ -414,6 +458,32 @@ section('Rejections — the status table, with a running KV write count');
     arrayBuffer: reader,
   }, 413);
   eq(bodyWasRead, true, 'the body was read before that one was rejected');
+
+  // 413 — a LYING Content-Length with a huge streamed body. This is the case
+  // that used to buffer the lot: the header claims 42 bytes, the stream would
+  // happily deliver 12 MB. The reader must stop after the first chunk that
+  // crosses 8192 bytes and cancel the stream, never calling arrayBuffer().
+  let chunksPulled = 0;
+  let streamCancelled = false;
+  const bigChunk = new TextEncoder().encode('z'.repeat(64 * 1024));  // 64 KB a chunk
+  const lyingStream = new ReadableStream({
+    pull(controller) {
+      chunksPulled++;
+      if (chunksPulled > 200) { controller.close(); return; }   // 12.8 MB if fully drained
+      controller.enqueue(bigChunk);
+    },
+    cancel() { streamCancelled = true; },
+  });
+  await rejects('413 on a huge streamed body behind a small Content-Length', {
+    method: 'POST',
+    url: ENDPOINT,
+    cf: undefined,
+    headers: fakeHeaders({ Origin: ORIGIN, 'Content-Type': 'application/json', 'Content-Length': '42' }),
+    body: lyingStream,
+    async arrayBuffer() { throw new Error('arrayBuffer() was called on a streamed body — the read is unbounded again'); },
+  }, 413);
+  ok(chunksPulled <= 2, `the stream was abandoned after the chunk that crossed the cap (pulled ${chunksPulled} x 64 KB, not 200)`);
+  ok(streamCancelled, 'the oversized stream was cancelled rather than left to drain');
 
   // 400 — malformed JSON and wrong shapes.
   await rejects('400 on malformed JSON', post(null, { raw: '{"type":"bug",' }), 400);
@@ -444,6 +514,13 @@ section('Rejections — the status table, with a running KV write count');
   await rejects('400 on an email with no @', post(body({ email: 'not-an-email' })), 400);
   await rejects('400 on an email with a space', post(body({ email: 'a b@example.com' })), 400);
   await rejects('400 on a non-string email', post(body({ email: 42 })), 400);
+  // Over the 254-unit cap but otherwise a perfectly well-formed address, so
+  // only the length check can reject it.
+  await rejects('400 on an email over 254 units', post(body({ email: 'a'.repeat(250) + '@example.com' })), 400, async (r) => {
+    eq((await readJson(r)).error, 'bad_email', 'the over-length email is a bad_email rejection');
+  });
+  const atEmailCap = 'b'.repeat(254 - '@example.com'.length) + '@example.com';
+  eq(atEmailCap.length, 254, 'the boundary address really is exactly 254 units');
 
   eq(kv.writes, 0, 'ZERO KV writes across every rejection path above');
   eq(kv.store.size, 0, 'and nothing at all is in the store');
@@ -466,11 +543,9 @@ section('Boundaries that must pass');
   const atGate = await call(post(body({ dwell: 1000 })), env);
   eq(atGate.status, 200, 'a dwell of exactly 1000 ms is accepted');
 
-  const noEmail = await call(post(body({ email: '' })), env);
-  eq(noEmail.status, 200, 'an empty email is treated as no email');
-  const last = env.FEEDBACK.records();
-  const record = JSON.parse(env.FEEDBACK.store.get(last[0]).value);
-  ok(record.email === null || typeof record.email === 'string', 'email is null or a string, never undefined');
+  const atCap = 'b'.repeat(254 - '@example.com'.length) + '@example.com';
+  const emailAtCap = await call(post(body({ email: atCap })), env);
+  eq(emailAtCap.status, 200, 'an email of exactly 254 units is accepted');
 
   const emoji = await call(post(body({ message: '👍'.repeat(1000) })), env);
   eq(emoji.status, 200, '1000 surrogate pairs = 2000 UTF-16 units is accepted, matching maxlength');
@@ -479,6 +554,61 @@ section('Boundaries that must pass');
 
   const noContext = await call(post({ type: 'idea', message: 'no context at all', dwell: 3000 }), env);
   eq(noContext.status, 200, 'context and viewport are optional');
+}
+
+section('A submission with no email stores null, and says so in the metadata');
+{
+  // A fresh env per case, so the record under test is the only one in it and
+  // the assertions cannot be satisfied by some earlier submission's record.
+  for (const [label, payload] of [
+    ['omitted entirely', { type: 'idea', message: 'no email on this one', dwell: 3000 }],
+    ['an empty string', body({ email: '' })],
+    ['whitespace only', body({ email: '   ' })],
+    ['explicit null', body({ email: null })],
+  ]) {
+    const env = makeEnv();
+    const response = await call(post(payload), env);
+    eq(response.status, 200, `200 when the email is ${label}`);
+    const keys = env.FEEDBACK.records();
+    eq(keys.length, 1, `exactly one record when the email is ${label}`);
+    const entry = env.FEEDBACK.store.get(keys[0]);
+    const record = JSON.parse(entry.value);
+    eq(record.email, null, `the stored email is null when it is ${label}`);
+    eq(entry.metadata.hasEmail, false, `metadata.hasEmail is false when the email is ${label}`);
+  }
+
+  // And the positive case, so the flag is proved to move rather than being
+  // constant in either direction.
+  const withEmail = makeEnv();
+  await call(post(body({ email: 'someone@example.com' })), withEmail);
+  const entry = withEmail.FEEDBACK.store.get(withEmail.FEEDBACK.records()[0]);
+  eq(JSON.parse(entry.value).email, 'someone@example.com', 'and a supplied email is stored as given');
+  eq(entry.metadata.hasEmail, true, 'and metadata.hasEmail is true when there is one');
+}
+
+section('An oversized context value is clipped, not stored whole');
+{
+  const env = makeEnv();
+  await call(post(body({
+    context: {
+      hash: '#' + 'h'.repeat(5000),
+      season: 's'.repeat(400),
+      age: 'GU15',
+      conference: null,
+      view: 12345,                        // not a string: dropped, not coerced
+      tab: 't'.repeat(200),               // exactly at the cap
+      extra: 'not a whitelisted field',   // must not survive
+    },
+  })), env);
+  const record = JSON.parse(env.FEEDBACK.store.get(env.FEEDBACK.records()[0]).value);
+  eq(record.context.hash.length, 200, 'an oversized context hash is clipped to 200 units');
+  eq(record.context.season.length, 200, 'an oversized context season is clipped to 200 units');
+  eq(record.context.tab.length, 200, 'a context value of exactly 200 units survives intact');
+  eq(record.context.age, 'GU15', 'a normal context value is untouched');
+  eq(record.context.view, null, 'a non-string context value becomes null, not a coerced string');
+  eq(record.context.conference, null, 'an explicit null stays null');
+  eq('extra' in record.context, false, 'a field outside the whitelist never reaches the record');
+  eq(Object.keys(record.context).length, 6, 'the context is exactly the six whitelisted fields');
 }
 
 // --- 8. the honeypot is the ONLY silent discard ---------------------------
@@ -514,11 +644,19 @@ section('429 — the per-address daily limit, read-only');
   eq(accepted, 10, 'ten submissions from one address are accepted in a UTC day');
   ok(limited !== null, 'the eleventh is rejected');
   eq(limited.status, 429, 'the limit is a 429');
-  eq(limited.headers.get('Retry-After'), '86400', 'the 429 says when to come back');
+  // The bucket is keyed on the UTC date, so Retry-After must be the seconds
+  // left until UTC midnight, not a flat 86400 that over-promises all day.
+  const retryAfter = Number(limited.headers.get('Retry-After'));
+  const untilMidnight = Math.ceil((Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), new Date().getUTCDate() + 1) - Date.now()) / 1000);
+  ok(Number.isInteger(retryAfter) && retryAfter > 0, 'the 429 says when to come back, as a positive integer of seconds');
+  ok(retryAfter <= 86400, `Retry-After never exceeds a day (got ${retryAfter})`);
+  ok(Math.abs(retryAfter - untilMidnight) <= 2, `Retry-After is the seconds left until UTC midnight (got ${retryAfter}, expected about ${untilMidnight})`);
 
   const before = env.FEEDBACK.writes;
+  const beforeReads = env.FEEDBACK.reads;
   await call(post(body({ message: 'and another' })), env);
   eq(env.FEEDBACK.writes - before, 0, 'a rate-limited request performs ZERO KV writes');
+  eq(env.FEEDBACK.reads - beforeReads, 4, 'a rate-limited request costs 4 KV reads (the address counter shards) and stops there');
 
   // A different address is unaffected: the limit is per address, not global.
   const other = await call(post(body(), { address: '192.0.2.55' }), env);
@@ -547,6 +685,73 @@ section('503 — the global daily cap fails closed');
   eq((await call(post(body()), env2)).status, 200, 'one below the cap is still accepted (shards are summed)');
 }
 
+section('The rate-limit bucket is never attacker-chosen');
+{
+  // CF-Connecting-IP is the only address source. X-Forwarded-For is
+  // client-supplied, so honouring it would hand a flooder a fresh daily
+  // allowance per spoofed value; without CF-Connecting-IP every request must
+  // land in one shared 'unknown' bucket instead.
+  const env = makeEnv();
+  let accepted = 0;
+  for (let i = 0; i < 12; i++) {
+    const response = await call(post(body({ message: 'spoof attempt ' + i }), {
+      address: null,
+      headers: { 'X-Forwarded-For': '198.51.100.' + i },
+    }), env);
+    if (response.status === 200) accepted++;
+  }
+  eq(accepted, 10, 'twelve different X-Forwarded-For values still share ONE bucket — only 10 get through');
+
+  const unknownHash = await expectedAddressHash('unknown');
+  const rlKeys = [...env.FEEDBACK.store.keys()].filter((k) => k.startsWith('rl:'));
+  ok(rlKeys.length > 0 && rlKeys.every((k) => k.includes(unknownHash)), 'the bucket is the constant "unknown", not any header the client sent');
+  for (let i = 0; i < 12; i++) {
+    const spoofed = await expectedAddressHash('198.51.100.' + i);
+    ok(rlKeys.every((k) => !k.includes(spoofed)), 'no bucket is derived from an X-Forwarded-For value');
+  }
+}
+
+// --- 10b. the KV cost per path, which the free-tier arithmetic rests on ---
+
+section('KV reads and writes per path — the free-tier arithmetic');
+{
+  // The README's budget: 14 reads + 3 writes per accepted submission, 4 reads
+  // + 0 writes per rate-limited one, and the WAF rule is the only thing
+  // bounding the read spend on the rejected path. Pin all three numbers, so a
+  // change to the shard counts has to come here and update the README with it.
+  const env = makeEnv();
+  const kv = env.FEEDBACK;
+
+  const r0 = kv.reads, w0 = kv.writes;
+  eq((await call(post(body()), env)).status, 200, 'the costed submission is accepted');
+  eq(kv.reads - r0, 14, 'an accepted submission costs 14 KV reads (4 address shards + 8 global shards + 1 per counter bump)');
+  eq(kv.writes - w0, 3, 'an accepted submission costs 3 KV writes (record + 2 counter shards)');
+
+  // Free-tier arithmetic, stated as an assertion rather than as prose.
+  eq(200 * 3, 600, '200 accepted submissions is 600 writes, inside the free 1000/day');
+  ok(200 * 14 < 100000, '200 accepted submissions is 2800 reads, well inside the free 100000/day');
+  ok(Math.floor(100000 / 4) === 25000, 'and 4 reads on the rate-limited path means ~25k rejected requests exhausts the daily read budget');
+
+  // Every check before storage is free: no KV traffic at all on a rejection
+  // that never reaches the limiter.
+  const r1 = kv.reads, w1 = kv.writes;
+  await call(post(body(), { origin: 'https://evil.example' }), env);
+  await call(post(body(), { contentType: 'text/plain' }), env);
+  await call(post(body(), { contentLength: null }), env);
+  await call(post(body({ dwell: 10 })), env);
+  await call(post(body({ message: '' })), env);
+  eq(kv.reads - r1, 0, 'a rejection before the storage checks costs ZERO KV reads');
+  eq(kv.writes - w1, 0, 'and zero writes');
+
+  // At the global cap: both counters are read, nothing is written.
+  const capped = makeEnv();
+  capped.FEEDBACK.seed('gc:' + TODAY + ':0', 200);
+  const r2 = capped.FEEDBACK.reads;
+  eq((await call(post(body()), capped)).status, 503, 'the capped submission is a 503');
+  eq(capped.FEEDBACK.reads - r2, 12, 'a capped request costs 12 KV reads (4 address shards + 8 global shards)');
+  eq(capped.FEEDBACK.writes, 0, 'and zero writes');
+}
+
 // --- 11. missing binding, missing salt ------------------------------------
 
 section('503 — missing binding and missing salt');
@@ -573,28 +778,85 @@ section('503 — missing binding and missing salt');
 
 // --- 12. a thrown route error still serves the site -----------------------
 
-section('A fault in the route still falls through to the assets');
+section('A fault always produces a Response, and never a consumed-Request retry');
 {
+  // A storage fault on the feedback path. By this point the body has been
+  // read, so retrying env.ASSETS.fetch(request) would throw in production —
+  // the fake assets binding above throws too, so if the worker tried it this
+  // test would see a 503 with no asset call, or an escape.
   const env = makeEnv({ FEEDBACK: makeKV({ failPut: true }) });
   let response;
   try {
     response = await call(post(body()), env);
   } catch (err) {
-    failures.push('a KV fault escaped the handler instead of falling through to the assets: ' + err.message);
-    response = new Response('', { status: 599 });
+    failures.push('a KV fault escaped the handler entirely: ' + err.message);
+    response = new Response('{}', { status: 599, headers: { 'Content-Type': 'application/json; charset=utf-8', 'Cache-Control': 'no-store' } });
   }
-  eq(response.headers.get('X-Served-By'), 'assets', 'a KV fault falls through to env.ASSETS.fetch');
-  eq(response.status, 200, 'the fallback response is the asset response, not a 500');
-  eq(env.ASSETS.calls, 1, 'the assets binding was used exactly once');
+  eq(response.status, 503, 'a storage fault on the feedback path is a 503, not a 500 and not an asset page');
+  const faultJson = await readJson(response);
+  eq(faultJson.ok, false, 'the fault reply is JSON, which is what the client parses');
+  eq(faultJson.retry, true, 'the fault reply carries {retry:true} so the client can keep the typed text');
+  eq(response.headers.get('X-Served-By'), null, 'the feedback path does NOT fall through to the assets');
+  eq(env.ASSETS.calls, 0, 'the assets binding is not touched with an already-read Request');
+  eq(response.headers.get('Cache-Control'), 'no-store', 'the fault reply is no-store like every other one');
+
+  // The consumed-Request rule the fake assets binding enforces is real: prove
+  // the harness would actually catch a fall-through here.
+  const consumed = post(body());
+  await consumed.text();
+  eq(consumed.bodyUsed, true, 'reading a Request body sets bodyUsed');
+  let assetsThrew = false;
+  try {
+    await makeAssets().fetch(consumed);
+  } catch (err) {
+    assetsThrew = true;
+  }
+  ok(assetsThrew, 'the fake assets binding rejects an already-read Request, as production does');
 
   // The same fault must not stop the site serving pages.
   const page = await call(new Request(ORIGIN + '/'), env);
   eq(page.headers.get('X-Served-By'), 'assets', 'page views are unaffected by a broken feedback route');
+  eq(env.ASSETS.calls, 1, 'and that page view is the first and only asset call in this env');
 
-  // And a fault in the assets binding itself cannot crash the redirect.
+  // A fault in the assets binding itself cannot crash the redirect.
   const brokenAssets = makeEnv({ ASSETS: { async fetch() { throw new Error('assets down'); } } });
   const redirect = await call(new Request('https://ecnl-dashboard.nextonetwolabs.workers.dev/'), brokenAssets);
   eq(redirect.status, 301, 'the redirect does not depend on the assets binding');
+
+  // ...and a page view with a broken assets binding degrades to a 503 rather
+  // than throwing out of fetch(). The catch's own body must not be able to
+  // throw.
+  let brokenPage;
+  try {
+    brokenPage = await call(new Request(ORIGIN + '/'), brokenAssets);
+  } catch (err) {
+    failures.push('a broken ASSETS binding escaped fetch() as an unhandled rejection: ' + err.message);
+    brokenPage = new Response('', { status: 599 });
+  }
+  eq(brokenPage.status, 503, 'a broken assets binding is a 503, not an unhandled rejection');
+
+  // env.ASSETS missing altogether — the catch used to dereference it blindly.
+  const noAssets = makeEnv({ ASSETS: undefined });
+  let missing;
+  try {
+    missing = await call(new Request(ORIGIN + '/'), noAssets);
+  } catch (err) {
+    failures.push('a missing ASSETS binding escaped fetch() as an unhandled rejection: ' + err.message);
+    missing = new Response('', { status: 599 });
+  }
+  eq(missing.status, 503, 'a missing ASSETS binding is a 503, not an unhandled rejection');
+
+  // And on the feedback path with no assets binding at all: still JSON.
+  const noAssetsFeedback = makeEnv({ ASSETS: undefined, FEEDBACK: makeKV({ failPut: true }) });
+  let missingFeedback;
+  try {
+    missingFeedback = await call(post(body()), noAssetsFeedback);
+  } catch (err) {
+    failures.push('a fault with no ASSETS binding escaped fetch(): ' + err.message);
+    missingFeedback = new Response('{}', { status: 599, headers: { 'Content-Type': 'application/json; charset=utf-8', 'Cache-Control': 'no-store' } });
+  }
+  eq(missingFeedback.status, 503, 'a storage fault with no assets binding is still a 503');
+  eq((await readJson(missingFeedback)).retry, true, 'and still carries {retry:true}');
 }
 
 // --- 13. no CORS headers, anywhere ----------------------------------------

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,9 +2,12 @@
 #
 # The site is the static files in public/ — the same directory the local
 # server serves, so the deployed site is byte-identical to a local run. The
-# tiny worker.js only redirects the workers.dev address to the canonical
-# custom domain; it runs ahead of the assets for "/" alone, so everything
-# else is served as free static assets without invoking the Worker.
+# worker.js beside this file redirects the workers.dev address to the
+# canonical custom domain and serves POST /api/feedback; it runs ahead of the
+# assets for "/" alone, so everything else is served as free static assets
+# without invoking the Worker. /api/feedback matches no file in public/, so it
+# reaches the Worker without any change to run_worker_first — do not add it
+# there, that line also governs page serving.
 #
 # Canonical address: https://ecnl.nextonetwo.com  (custom domain, attached to
 # this Worker in the Cloudflare dashboard under Settings -> Domains & Routes).
@@ -17,3 +20,23 @@ compatibility_date = "2026-08-31"
 directory = "./public"
 binding = "ASSETS"
 run_worker_first = ["/"]
+
+# Private storage for visitor feedback (POST /api/feedback). Records expire on
+# their own after 180 days; rate-limit counters after 24 hours.
+#
+# >>> PLACEHOLDER — THIS PR MUST NOT MERGE UNTIL THE OWNER REPLACES IT <<<
+# The owner runs:  npx wrangler kv namespace create FEEDBACK
+# and pastes the printed id below in place of the placeholder. A deploy with
+# the placeholder id FAILS, and a failed deploy is silent — it would also
+# freeze the two-hourly data refresh, which ships through the same deploy.
+[[kv_namespaces]]
+binding = "FEEDBACK"
+id = "REPLACE_ME_WITH_THE_REAL_FEEDBACK_NAMESPACE_ID"
+
+# Also required before this route works, both owner actions:
+#   npx wrangler secret put FEEDBACK_SALT   (32 random bytes; keys the per-day
+#     address hash used only for rate limiting — without it the endpoint fails
+#     closed with 503 and stores nothing)
+#   a WAF rate-limiting rule on /api/feedback (free plan includes one) — every
+#     page view is already a Worker request against a 100k/day budget, so a
+#     flood on this route would take the homepage down before our code runs.


### PR DESCRIPTION
## Goal

Resolve part of #26. Visitors have no way to tell us something is wrong without a GitHub account, so the Worker gains the site's one dynamic route: `POST /api/feedback`, which validates a small JSON submission and writes it to a private Cloudflare KV namespace on the same account. Nothing leaves our own hosting, there is no third-party form service, and the sender needs no signup. This is the Worker half only — the dialog that posts to it is PR 2 and is not in this branch, so on merge the endpoint exists with no UI, which is harmless because the whole protection stack ships with it.

Part of #26

**DO NOT MERGE until:**

1. **The owner has created the WAF rate-limiting rule on `/api/feedback`** (the free plan includes one). This is the only defence that protects the *site*: every page view is already a Worker request against the free tier's 100k/day, so a flood on this route would take the homepage down before any of our code runs.
2. **The owner has run `npx wrangler kv namespace create FEEDBACK`** and the real id has replaced `REPLACE_ME_WITH_THE_REAL_FEEDBACK_NAMESPACE_ID` in `wrangler.toml`.
3. **The owner has run `npx wrangler secret put FEEDBACK_SALT`** with 32 random bytes (`openssl rand -base64 32`). Without it the endpoint fails closed with 503 and stores nothing, which is safe but useless.

A deploy with the placeholder namespace id **fails**, and a failed deploy is silent — it would also freeze the two-hourly data refresh, which ships through the same deploy, so the site's data would quietly go stale.

## Summary of change

- **`worker.js`** — rewritten, but the `workers.dev` → canonical redirect stays first and behaves exactly as before, and everything else still falls through to `env.ASSETS.fetch`. The whole `fetch()` body is wrapped in a catch that **always returns a Response**, and every new line lives inside the handler: a throw at module scope would kill every page view and no try/catch could save it. Checks run in a deliberate order — method, `Origin`, content type, `Content-Length`, parse, honeypot, dwell, then type and length — and **KV is not touched until all of them pass, and is never written on a rejection**. Statuses: `200 {ok,id}` stored; `200 {ok}` with nothing stored for the honeypot alone; `400` for malformed JSON, bad or missing type, empty message, message over 2000 UTF-16 units, bad email, non-numeric dwell or a dwell under the 1000 ms backstop; `403` for a missing or foreign `Origin`; `405` with `Allow: POST` for every other method including GET, HEAD and OPTIONS; `411` when `Content-Length` is absent or not a plain integer, so a chunked or unlabelled body is refused before it is read; `413` on `Content-Length` over 8192 or a body that exceeds it on read; `415` for a content type that is not `application/json` (a `; charset=utf-8` parameter is accepted); `429` on the per-address daily limit, decided by a **read alone**, with `Retry-After` set to the seconds left until UTC midnight when the day-keyed bucket actually resets; `503 {retry:true}` when the binding or the salt is missing or the global daily cap is reached, all failing closed. Every response is JSON with `Cache-Control: no-store`, never carries an `Access-Control-*` header, and never echoes the submission. Records are keyed `fb:<13-digit inverted ms>:<uuid>` with metadata `{t,type,len,hasEmail,country}` and a 180-day `expirationTtl`; the address is turned into a key name by `HMAC(HMAC(FEEDBACK_SALT, <UTC date>), address)` and never enters a record in any form. `request.cf` being undefined is handled.
- **`wrangler.toml`** — adds the `[[kv_namespaces]]` binding for `FEEDBACK` with a loudly marked placeholder id and a comment saying this PR must not merge until the owner pastes the real one. **`run_worker_first` is untouched**: `/api/feedback` matches no file in `public/`, so it already reaches the Worker, and that line also governs page serving.
- **`worker.test.mjs`** — new, committed, at the repo root. Zero dependencies, no `package.json`, `node worker.test.mjs`.
- **`.gitignore`** — adds `.wrangler/` and `node_modules/`, since the refresh workflow stages everything with `git add -A`.
- **`README.md`** — a "Visitor feedback" section documenting the endpoint and its status table, every protection and honestly what they do not stop, what is stored and the 180-day/24-hour retention, how the team reads submissions with a read-only expiring Cloudflare API token, and how to run the tests.

### Second commit — the security review (`452edc2`)

The Reviewer requested changes on two fault-containment defects, both in the property this PR claims to guarantee. Both are fixed, along with everything else raised.

- **Must-fix 1 — the body read was unbounded.** `Number(null)` is `0`, so an absent or chunked `Content-Length` passed the size gate and `request.arrayBuffer()` then buffered the body whole — up to Cloudflare's 100 MB — into a 128 MB isolate before anything measured it. A plain-integer `Content-Length` is now **required**: `411` when it is absent or unparseable, `413` when it is over 8192. And because a header is only a claim, the body is then read through a reader that **cancels the stream** the moment the accumulated byte count crosses the cap, so a lying or chunked length costs one chunk and never a buffered 100 MB. The post-read byte check is kept as a belt-and-braces assertion.
- **Must-fix 2 — the catch was not total.** On the feedback path the body has usually been read by the time anything can fault, and `env.ASSETS.fetch()` on a consumed `Request` throws, so a storage fault **500'd** instead of falling through; and `env.ASSETS` being undefined made the catch's own body throw an unhandled rejection. The catch now returns the retry-later `503 {ok:false,retry:true}` JSON on the feedback path — which is what PR 2's client expects anyway — and wraps the remaining asset fallback in its own try/catch that degrades to a plain `503`. **Nothing can escape `fetch()` without returning a Response.**
- **The harness weakness that hid this is fixed too.** The fake `ASSETS` binding ignored body state, so the fall-through test passed vacuously for exactly the case it existed to prove. It now **throws when handed a Request with `bodyUsed === true`**, mirroring production, and a storage fault on the feedback path is asserted to be 503 JSON — not an asset response, not a throw.
- **Dropped the `X-Forwarded-For` fallback** for the rate-limit bucket. It fell back to a client-supplied header, so if `CF-Connecting-IP` were ever absent the bucket became attacker-chosen — a fresh daily allowance per spoofed value. It now falls back to the constant `'unknown'`, which fails the way a limiter should.
- **README** — the "what stops abuse" section now says the WAF rule is also the **only bound on KV read spend**, with the measured cost per path: **14 reads + 3 writes per accepted submission, 4 reads + 0 writes per rate-limited one**. Four reads on the *rejected* path means roughly **25,000 rejected requests exhaust the free daily read budget**, after which the reads themselves fail, the limiter check throws, and the endpoint degrades to `503 {retry:true}` for the rest of the UTC day. Pages keep serving — they are static assets and touch no KV.
- **The three mutants the reviewer's spot-check found surviving now have tests**: a submission with no email asserting the stored `email === null` **and** `metadata.hasEmail === false` (the old check was a tautology), an over-length email rejected, and an oversized `context` value asserted to be clipped to 200 units — which is what the code does. The **KV read and write counts per path are asserted** as well, so the free-tier arithmetic above cannot drift out of date without a test failing.
- **Nits** — `Retry-After` on the `429` is the seconds until UTC midnight rather than a flat `86400` that over-promises all day; a `405` to `HEAD` carries no body.

## Testing plan

- [x] `node worker.test.mjs` — **PASS, 310 assertions, 0 failures, 116 worker responses exercised**, exit 0 (was 212 assertions before the review round). Covers every row of the status table, the key shape, that two records written a second apart list newest-first, that the zero padding is load-bearing (two submissions either side of the 13-digit boundary), **zero KV writes across every rejection path** (counted), the fail-closed 503 at the global cap, missing binding and missing salt, that an injected KV fault still falls through to the assets, that `request.cf === undefined` is handled, that no `Access-Control-*` header appears on any of the 80 responses, and that no record contains the address or its hash.
- [x] Mutation-checked the harness: 11 deliberate faults injected into `worker.js` (CORS header added, silent 200 on dwell, un-inverted key, un-padded key, cap failing open, a write on the 429 path, a strict content-type check, the try/catch rethrowing, the `Origin` check removed, the address stored in the record, the honeypot storing). **All 11 were caught.**
- [x] **Re-run mutation check after the review round — 12 of 12 caught, exit 1 on every one.** The three the reviewer found surviving: forcing `metadata.hasEmail` true (*"metadata.hasEmail is false when the email is omitted entirely — expected false, got true"*), removing the email-length cap (*"400 on an email over 254 units — expected 400, got 200"*), removing the context-length cap (*"an oversized context hash is clipped to 200 units — expected 200, got 5001"*). One for each must-fix: removing the `Content-Length` requirement, i.e. restoring the `Number(null) === 0` gate (*"411 when Content-Length is absent (chunked or stripped) — expected 411, got 200"*, 17 failures) and restoring the asset fetch in the catch on the feedback path (*"the fault reply is JSON, which is what the client parses — expected false, got undefined"*). Plus: replacing the bounded reader with an unbounded `arrayBuffer()` (*"413 on a huge streamed body behind a small Content-Length — expected 413, got 503"*), restoring the `X-Forwarded-For` fallback (*"twelve different X-Forwarded-For values still share ONE bucket — only 10 get through — expected 10, got 12"*), a flat `Retry-After: 86400` (*"expected about 14569"*), a body on the `405` to `HEAD`, removing the inner try/catch around the asset fallback (*"a broken ASSETS binding escaped fetch() as an unhandled rejection"*), and the two the reviewer had already confirmed caught (daily limit 10 → 11, user-agent truncation removed).
- [x] `node --check worker.js` and `node --check worker.test.mjs` — clean; `import('./worker.js')` exports a `fetch` function.
- [x] `npx wrangler dev` (local, **no login required**) — the real `workerd` runtime accepted the module and the route: GET and OPTIONS → 405, missing and foreign `Origin` → 403, `text/plain` → 415, `application/json; charset=utf-8` → 200, a 9 KB body → 413, malformed JSON → 400, `dwell: 200` → 400, a filled honeypot → 200 with no id, a good submission → `200 {ok,id}`, and **the homepage still served normally** throughout.
- [x] **`npx wrangler dev` re-probed after the review round** (local only, no login), real status codes: homepage → **200** (190 691 bytes of assets); a chunked upload with no `Content-Length` → **411** `{"error":"length_required"}`; `Content-Length: lots` → **411**; a 20 MB body with a declared length → **413** `{"error":"too_large"}`; a body of exactly 8192 bytes → **200** `{ok,id}`; exactly 8193 bytes → **413**; a normal submission → **200** `{"ok":true,"id":"5e59bd1d-…"}`; `HEAD /api/feedback` → **405**, `Allow: POST`, **zero bytes of body**; `GET /api/feedback` → **405** with the JSON explanation; four concurrent 20 MB chunked posts → **411 on all four**, and the homepage still served throughout.
- [x] `wrangler kv key list --local` against what that run wrote: keys `fb:8210930681269:…` and `fb:8210930681952:…` listed **newest first**, metadata present, record expiry 15 552 000 s (180 days) and counter expiry 86 400 s, counters landing on different shards (`gc:…:2`, `gc:…:6`), and the stored record containing no address and no hash.
- [x] `git diff --stat origin/main...HEAD` touches only the five files — `.gitignore` 6+, `README.md` 176±, `worker.js` 466±, `worker.test.mjs` 897+, `wrangler.toml` 29± — `public/index.html` and all data, archive, workflow and Python files are untouched; no CR/LF churn (all five files were CRLF and still are, with zero bare-LF lines in the three the review round touched).
- [ ] **The isolate-memory difference cannot be demonstrated in `wrangler dev --local`, and is not claimed to have been.** Two attempts, reported as they came out. (1) A side-by-side of the fixed worker against a copy carrying the pre-review code (the `Number(null) === 0` gate plus `arrayBuffer()`), four concurrent 20 MB chunked posts at each: the pre-review copy's isolate-host `workerd` grew **+80.4 MB for the 80 MB offered** — the body being buffered, exactly the defect — but the fixed one grew **+114.4 MB**, because local `workerd` buffers the incoming body itself whether or not the handler reads it, so the figure measures the runtime's ingress buffering and cannot separate the two. (2) A slowloris (1 MB of chunks, then silence, connection held): the pre-review copy logged `POST /api/feedback 413 Payload Too Large (12006ms)` — twelve seconds sitting inside the handler holding an attacker-controlled body — where the fixed worker's only completed POST of that shape was `411 Length Required (7ms)`; but later rounds of the same probe emitted no completion line on either server, so that is suggestive, not repeatable. **The deterministic evidence for the bound is in the harness instead**, where the streamed-body test offers 200 chunks of 64 KB behind a `Content-Length: 42` and asserts the reader pulled at most 2 of them and cancelled the stream — the unbounded-`arrayBuffer()` mutant fails it.
- [ ] Real KV, `cf.country` from real traffic, cross-address rate limiting, and the WAF rule firing — **cannot be run locally**. `wrangler dev` simulates KV in a single local instance, so eventual consistency, the hot-key write rate and the real 1000-writes/day budget are not exercised; it also synthesises a `cf` object, so the undefined case is only covered by the harness; and the WAF rule lives in the Cloudflare dashboard, not in this repo.
- [ ] Website Auditor verifies live after merge

## Potential risks and suggestions

- **The rate limiter is the documented KV fallback, not the Workers Rate Limiting binding.** I could not confirm current, free-plan-safe syntax for the binding, and the plan said not to guess. It is configured as an `[[unsafe.bindings]]` entry, its free-plan availability is undocumented, its period is limited to a few seconds rather than the day this limiter needs, and it counts per Cloudflare location rather than globally. A binding the deploy rejects would fail the deploy **silently** and freeze the data refresh, which is too high a price for a guess. The KV limiter ships instead, with the WAF rule in front as the defence that actually protects the site. If the owner later confirms the binding is available, swapping it in is a small, well-tested change.
- **Eventual consistency means the global cap can overshoot.** KV reads are cached at the edge for up to a minute, so a burst can push past 200 accepted submissions before every colo sees the counter. Three writes per accepted submission puts the intended worst day at 600 of the free tier's 1000, so there is real headroom for the overshoot; the WAF rule bounds how large a burst can be.
- **Counters are sharded to avoid hot keys** — 8 shards for the global counter, 4 per address, one picked at random per write and all summed on read — because KV allows only about one write per second per key and a burst would otherwise fail on the counter rather than on the record. Counter writes are also best-effort: the record is written first, so a counter write that loses a race cannot turn a stored message into an error for the person who sent it. The cost is that the limiter can undercount slightly under a burst, which the WAF rule bounds.
- **The read token is account-scoped.** Cloudflare's Workers KV Storage → Read permission cannot be narrowed to one namespace, so the token reads every KV namespace on the account — today, only this one. Mitigations are the expiry and one-click revocation with no deploy. **If a second namespace is ever created on this account, rotate or re-scope the token.**
- **A `503` is the answer to a missing `FEEDBACK_SALT`.** No salt means no rate limiting, and an unlimited public write endpoint is worse than a closed one, so it fails closed rather than accepting unlimited submissions. The site keeps serving pages either way.
- **`www.ecnl.nextonetwo.com` does not resolve** (checked), so the `Origin` allowlist is the single canonical host. `nextonetwo.com` and `www.nextonetwo.com` do resolve, but they are the marketing site and do not embed this form, so they are deliberately not on the list. One line in `worker.js` adds a host if that ever changes.
- **The honeypot field name is `subjectline`** and PR 2's client must match it exactly, or every genuine submission is silently discarded. The harness pins the name so the two cannot drift apart unnoticed.
- **The dwell rejection is a visible `400`, not a silent success**, per the re-review. The honeypot is the only silent discard.
- **A fault in this route now answers `503 {ok:false,retry:true}` in JSON**, not the asset response — changed in the review round, because retrying `env.ASSETS.fetch()` with an already-read `Request` throws and turned a storage fault into a 500. PR 2's client gets JSON on every feedback reply and can keep the typed text; it should still treat an unexpected or non-JSON reply as a generic failure. Page views are unaffected and still fall through to the assets, inside their own try/catch.
- **Visitors whose privacy extensions strip `Origin` get a `403`,** and there is nothing this route can do about it — the allowlist is the cheapest real defence it has. PR 2's copy should therefore not tell them to try again, since a retry will fail the same way; that is a note for PR 2, not a change here.
- **Same-millisecond submissions order arbitrarily** within the uuid suffix. Harmless for triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

