### PR TITLE
Visitors can send feedback from the sidebar / details panel, POST /api/feedback, FEEDBACK KV / For Issue #26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ Thumbs.db
 # archive/ and export/ are deliberately committed — they are the durable local
 # copy of the standings and schedule data, and git gives them dated history.
 *.tmp
+
+# `npx wrangler dev` writes both of these. The data refresh workflow commits
+# with `git add -A`, so anything left untracked here would be pushed.
+.wrangler/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -180,8 +180,10 @@ address without fetching every record. `hash` is the deep link the visitor was l
 (`#season=2026-27&age=GU16&conf=NorCal`), so "the standings look wrong" says which standings.
 
 **Records expire after 180 days.** Each `put` carries an `expirationTtl`, so KV deletes the record
-by itself — there is no cron job and no manual cleanup. There is no deletion path for an individual
-message, and the panel says so.
+by itself — there is no cron job and no manual cleanup. **We don't offer per-message deletion**, and
+the panel says so: nothing automates a request. A specific record can still be removed by hand with
+`npx wrangler kv key delete <key> --binding FEEDBACK --remote` — a key listing prints the reply
+address as metadata, so an emailed record is findable — but that is a manual, unadvertised path.
 
 **The message is free text.** It can contain anything a visitor chooses to type, including a name,
 a club, a player, or contact details the site never asked for and cannot validate. It is stored in
@@ -205,7 +207,9 @@ on your own machine.
 
 ### Spam and limits
 
-A hidden honeypot field drops the crudest bots, the message is capped at 2,000 characters and the
+A hidden honeypot field (`hp-note` — the name is deliberately odd, because browser address autofill
+ignores `autocomplete="off"` and fills anything called `website`, which would silently drop a real
+visitor's message) drops the crudest bots, the message is capped at 2,000 characters and the
 request body at 8 KB. Those bound each write, not how many arrive. **KV writes on the free plan are
 capped at 1,000 a day for the whole Cloudflare account**, and that budget is shared with the
 sibling site's waiting list — a flood of feedback here would break signups on `nextonetwo.com` too.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ upstream API or website ever goes away.
 - **One team search** — Find a team across every age group and conference in the current season; a result opens it on its conference page with the age group and team selected
 - **Age group navigation** — Tabs populated from the API; keyboard arrow-key navigation, `/` to search
 - **Dark mode**, and **deep links** (season, age group, conference, view, selected team and match filter in the URL hash)
+- **Send feedback** — A panel at the foot of the sidebar posts a message (and an optional reply
+  address) to the site's own Cloudflare Worker; see [Feedback](#feedback)
 - **Data explained** — Standings state that the order is as published by TGS (points per game, then goal difference), the header shows when the data was observed, and every view links to its source page on TGS
 
 ## How it works
@@ -158,6 +160,57 @@ falls back to a favourite, if any; for Playoffs the first stage, age group and
 competition) rather than the viewer's last state. The season can be changed from
 the Playoffs tab; the tab is kept and the hash follows the new season.
 
+## Feedback
+
+The **Send feedback** panel at the foot of the sidebar posts JSON to `POST /api/feedback`, handled
+by `worker.js` (the same Worker that serves the site). It writes one key per submission into the
+`FEEDBACK` KV namespace:
+
+    key:      <sent, ISO 8601>-<8 random hex characters>
+              e.g. 2026-09-10T18:04:21.512Z-9f3ac1b2
+    value:    { "sent": "<ISO 8601>", "message": "<what the visitor typed>",
+                "email": "<optional>", "hash": "<the URL hash the visitor was on>" }
+    metadata: { "email": "<the same address, or null>" }
+
+`email` and `hash` are left out of the value entirely when empty. The email cannot be the key: it
+is optional and not unique. The timestamp prefix makes a key listing come back in chronological
+order and readable by eye; the random suffix keeps two submissions in the same millisecond apart.
+The address is repeated as key metadata so a listing shows the date and whether there is a reply
+address without fetching every record. `hash` is the deep link the visitor was looking at
+(`#season=2026-27&age=GU16&conf=NorCal`), so "the standings look wrong" says which standings.
+
+**Records expire after 180 days.** Each `put` carries an `expirationTtl`, so KV deletes the record
+by itself — there is no cron job and no manual cleanup. There is no deletion path for an individual
+message, and the panel says so.
+
+**The message is free text.** It can contain anything a visitor chooses to type, including a name,
+a club, a player, or contact details the site never asked for and cannot validate. It is stored in
+plain text, readable by anyone with Cloudflare dashboard or `wrangler` access. Nothing else about
+the visitor is stored: no IP address, no user agent, no country, no viewport.
+
+### Reading submissions back
+
+    npx wrangler kv key list --binding FEEDBACK --remote
+    npx wrangler kv key get "2026-09-10T18:04:21.512Z-9f3ac1b2" --binding FEEDBACK --remote
+
+or in the Cloudflare dashboard under **Storage & Databases → KV**. Keys are not guessable, so
+reading feedback back is list-then-get, one call per submission — it is storage, not an inbox.
+
+> **A listing prints the metadata, so it prints every reply email.** Never paste a `kv key list`
+> output, or a screenshot of one, into a public issue, a PR, or a commit message.
+
+Add `--local` instead of `--remote` to read the simulated namespace that `npx wrangler dev` writes
+on your own machine.
+
+### Spam and limits
+
+A hidden honeypot field drops the crudest bots, the message is capped at 2,000 characters and the
+request body at 8 KB. Those bound each write, not how many arrive. **KV writes on the free plan are
+capped at 1,000 a day for the whole Cloudflare account**, and that budget is shared with the
+sibling site's waiting list — a flood of feedback here would break signups on `nextonetwo.com` too.
+If junk appears, the free plan includes one WAF rate-limiting rule per account; match `/api/*` so
+the one rule covers both sites.
+
 ## Layout
 
 | Path | What it is |
@@ -176,14 +229,16 @@ the Playoffs tab; the tab is kept and the hash follows the new season.
 | `ecnl_api.py` | Shared API/archive helpers |
 | `proxy_server.py` | Local static server, plus the `?live=1` API proxy |
 | `export/<season>/<conf>/` | CSVs — not published; `*.standings.csv`, `*.schedule.csv` |
+| `worker.js` | Redirects the `workers.dev` hostname, and handles `POST /api/feedback` |
+| `wrangler.toml` | Cloudflare Workers config: the `public/` assets and the `FEEDBACK` KV binding |
 | `.github/workflows/refresh.yml` | The 2-hourly scheduled refresh |
 | `ecnl-standings.html` | Deprecated first version, kept for reference |
 
 ## Deploying
 
 The site is a Cloudflare Worker serving static assets (`wrangler.toml` at the repo
-root: `[assets] directory = "./public"`, plus a ten-line `worker.js` that only
-redirects the `workers.dev` hostname). It is built by Cloudflare's Git integration
+root: `[assets] directory = "./public"`, plus a small `worker.js` that redirects the
+`workers.dev` hostname and handles `POST /api/feedback`). It is built by Cloudflare's Git integration
 on the **NextOneTwoLabs** Cloudflare account: repository `NextOneTwoLabs/ecnl-dashboard`,
 branch `main`, build command empty, deploy command `npx wrangler deploy`. Pushing to
 `main` — including the scheduled data commits — redeploys.
@@ -192,8 +247,8 @@ branch `main`, build command empty, deploy command `npx wrangler deploy`. Pushin
   Worker (the `nextonetwo.com` zone lives in the same Cloudflare account, so DNS and
   the certificate are managed automatically).
 - `https://ecnl-dashboard.nextonetwolabs.workers.dev` permanently redirects there
-  (`worker.js`, which runs ahead of the assets for `/` only, so page views cost one
-  Worker request and every other file is a free static asset).
+  (`worker.js`, which runs ahead of the assets for `/` and `/api/*` only, so page views
+  cost one Worker request and every other file is a free static asset).
 - `https://ecnl-dashboard.zhenyisx.workers.dev` — the original address — also
   redirects there, served by the tiny Worker in [`redirect/`](redirect/) from the
   original personal account.
@@ -203,6 +258,22 @@ Deep-link `#` fragments survive both redirects.
 The `workers.dev` subdomain belongs to the Cloudflare account, not to GitHub — moving
 the repository between GitHub owners does not change the URL, but Cloudflare's GitHub
 App must be installed on the new owner for builds to continue.
+
+**One-time setup for feedback.** The KV namespace must exist before the first deploy that
+references it, or the binding is missing and the panel fails:
+
+```bash
+npx wrangler kv namespace create FEEDBACK
+```
+
+Paste the id it prints into `wrangler.toml` under `[[kv_namespaces]]`. Because every push to
+`main` deploys — including the scheduled data commits — **never merge a binding that still holds
+the placeholder id**: the deploy fails silently and the data refresh stops reaching the live site.
+
+To run the Worker and the panel locally, `npx wrangler dev` and open
+<http://localhost:8787>. KV is simulated on your machine, so test submissions stay there.
+A plain `python -m http.server` in `public/` serves the page fine, but `/api/feedback`
+404s there — expected.
 
 ## Data Sources
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ the visitor is stored: no IP address, no user agent, no country, no viewport.
     npx wrangler kv key list --binding FEEDBACK --remote
     npx wrangler kv key get "2026-09-10T18:04:21.512Z-9f3ac1b2" --binding FEEDBACK --remote
 
-or in the Cloudflare dashboard under **Storage & Databases → KV**. Keys are not guessable, so
+or in the Cloudflare dashboard under **Storage & Databases → KV**, where the namespace is listed
+as `ECNL_FEEDBACK` (the binding is `FEEDBACK`; the title differs). Keys are not guessable, so
 reading feedback back is list-then-get, one call per submission — it is storage, not an inbox.
 
 > **A listing prints the metadata, so it prints every reply email.** Never paste a `kv key list`
@@ -259,16 +260,13 @@ The `workers.dev` subdomain belongs to the Cloudflare account, not to GitHub —
 the repository between GitHub owners does not change the URL, but Cloudflare's GitHub
 App must be installed on the new owner for builds to continue.
 
-**One-time setup for feedback.** The KV namespace must exist before the first deploy that
-references it, or the binding is missing and the panel fails:
+**Feedback KV namespace.** The namespace already exists on the NextOneTwoLabs account and its
+real id is in `wrangler.toml`, so there is nothing to create or paste before the first deploy.
 
-```bash
-npx wrangler kv namespace create FEEDBACK
-```
-
-Paste the id it prints into `wrangler.toml` under `[[kv_namespaces]]`. Because every push to
-`main` deploys — including the scheduled data commits — **never merge a binding that still holds
-the placeholder id**: the deploy fails silently and the data refresh stops reaching the live site.
+Its title on the account is `ECNL_FEEDBACK`, not `FEEDBACK`: the account already holds a
+`FEEDBACK` namespace belonging to the sibling marketing site, and two stores sharing one name
+would be indistinguishable in the dashboard. The binding is still `FEEDBACK`, so `env.FEEDBACK`
+in the Worker and the `--binding FEEDBACK` commands above are unaffected by the title.
 
 To run the Worker and the panel locally, `npx wrangler dev` and open
 <http://localhost:8787>. KV is simulated on your machine, so test submissions stay there.

--- a/public/index.html
+++ b/public/index.html
@@ -2105,13 +2105,17 @@
           <textarea id="feedbackMessage" name="message" rows="4" maxlength="2000" required></textarea>
           <label for="feedbackEmail">Email (optional, for a reply)</label>
           <input id="feedbackEmail" name="email" type="email" autocomplete="email" maxlength="254">
-          <input class="hp" name="website" type="text" tabindex="-1" autocomplete="off" aria-hidden="true">
+          <!-- Honeypot. The odd name is deliberate: Chrome's address autofill ignores
+               autocomplete="off" and fills fields called "website", which would silently
+               discard a real visitor's message. -->
+          <input class="hp" name="hp-note" type="text" tabindex="-1" autocomplete="off" aria-hidden="true">
           <button class="btn-primary" type="submit">Send</button>
         </form>
         <p class="feedback-note" id="feedbackNote" aria-live="polite"></p>
         <p class="feedback-privacy">Your message goes to our own private storage and is deleted
-          automatically after 180&nbsp;days. We can't delete an individual message on request.
-          Email is optional and used only to reply to you.</p>
+          automatically after 180&nbsp;days. We don't offer per-message deletion.
+          Email is optional and used only to reply to you. We also store which view of the site
+          you were on.</p>
       </details>
     </div>
 
@@ -4678,15 +4682,19 @@
       const t = e.target;
       const typing = t.closest && t.closest('input, select, textarea, [contenteditable="true"]');
       if (typing) return;
-      // An open feedback panel owns the keyboard: '/' would otherwise jump to the team search
-      // from the panel's Send button or summary, which are not caught by the check above.
-      if (t.closest && t.closest('#feedback[open]')) return;
-      if (e.key === '/' && !e.ctrlKey && !e.metaKey && !e.altKey) { e.preventDefault(); focusTeamSearch(); return; }
+      // An open feedback panel owns '/' and the arrow shortcuts: they would otherwise act from
+      // the panel's Send button or summary, which are not caught by the check above. Only those
+      // are suppressed — Escape still reaches the handler below and closes the sidebar drawer.
+      const inFeedback = !!(t.closest && t.closest('#feedback[open]'));
+      if (e.key === '/' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (inFeedback) return;
+        e.preventDefault(); focusTeamSearch(); return;
+      }
       if (e.key === 'Escape' && document.getElementById('sidebar').classList.contains('open')) { toggleSidebar(); return; }
       // Enter/Space activates focusable list items that aren't native buttons.
       if ((e.key === 'Enter' || e.key === ' ') && t.matches && t.matches('li[tabindex]')) { e.preventDefault(); t.click(); return; }
       // Arrow shortcuts browse conferences only, and never steal keys from a focused control.
-      if (currentTab !== 'conferences') return;
+      if (currentTab !== 'conferences' || inFeedback) return;
       if (t.closest && t.closest('button, a, [tabindex], [role="tab"]')) return;
       const names = Object.keys(getSeasonData().conferences);
       const ci = names.indexOf(currentConference);
@@ -4729,7 +4737,8 @@
             body: JSON.stringify({
               message: feedbackForm.elements.message.value,
               email: feedbackForm.elements.email.value,
-              website: feedbackForm.elements.website.value,
+              // See the markup: the honeypot's name is odd on purpose, to dodge autofill.
+              'hp-note': feedbackForm.elements['hp-note'].value,
               // Which view was open, so "the standings look wrong" says which standings.
               hash: location.hash,
             }),

--- a/public/index.html
+++ b/public/index.html
@@ -328,7 +328,9 @@
       transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
     }
     .season-select:hover { border-color: var(--accent-text); }
-    .season-select:focus-visible { border-color: var(--accent-text); box-shadow: 0 0 0 3px var(--accent-glow); outline: none; }
+    .season-select:focus-visible,
+    .feedback textarea:focus-visible,
+    .feedback input[type="email"]:focus-visible { border-color: var(--accent-text); box-shadow: 0 0 0 3px var(--accent-glow); outline: none; }
 
     .btn-primary {
       display: inline-block;
@@ -494,6 +496,69 @@
       font-family: var(--font);
       box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
     }
+
+    /* ===== FEEDBACK PANEL ===== */
+    .feedback {
+      border-top: 1px solid var(--border);
+      background: var(--bg-surface-alt);
+      padding: 10px 16px 14px;
+      font-size: 11px;
+      color: var(--text-secondary);
+    }
+
+    .feedback summary {
+      display: inline-block;
+      list-style: none;
+      color: var(--accent-text);
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      padding: 4px 0;
+    }
+    .feedback summary::-webkit-details-marker { display: none; }
+    .feedback summary:hover { color: var(--accent-hover); }
+
+    .feedback-prompt { margin-top: 8px; }
+
+    .feedback form {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      margin-top: 10px;
+    }
+    .feedback form[hidden] { display: none; }
+
+    .feedback label {
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .feedback textarea,
+    .feedback input[type="email"] {
+      width: 100%;
+      font: inherit;
+      font-size: 16px;              /* 16px keeps iOS from zooming the page on focus */
+      padding: 8px 10px;
+      color: var(--text-primary);
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+    }
+    .feedback textarea { resize: vertical; min-height: 76px; }
+    .feedback .btn-primary { align-self: flex-start; margin-top: 8px; }
+
+    /* The honeypot. Off-screen rather than display:none, which some bots skip. */
+    .feedback .hp {
+      position: absolute;
+      left: -9999px;
+      width: 1px;
+      height: 1px;
+      opacity: 0;
+    }
+
+    .feedback-note { margin-top: 8px; min-height: 1.5em; }
+    .feedback-note.is-ok { color: var(--accent-text); font-weight: 600; }
+    .feedback-privacy { margin-top: 10px; line-height: 1.5; }
 
     /* ===== MAIN CONTENT ===== */
     .main {
@@ -1191,6 +1256,8 @@
       .match-team { padding: 4px 0; }
       .glance-panel .glance-actions { display: flex; align-items: center; padding: 0 18px; }  /* outranks the later base rule */
       .glance-link { display: inline-flex; align-items: center; min-height: 44px; }
+      .feedback summary { display: inline-flex; align-items: center; min-height: 44px; }
+      .feedback input[type="email"] { min-height: 44px; }
     }
 
     @media (max-width: 480px) {
@@ -2027,6 +2094,25 @@
         <span class="hint-conf"><kbd>&larr;</kbd> <kbd>&rarr;</kbd> Age groups</span>
         <span class="hint-conf"><kbd>&uarr;</kbd> <kbd>&darr;</kbd> Conferences</span>
       </div>
+
+      <!-- Hidden until the script reveals it: the form has no plain-POST fallback, and the
+           dashboard needs JavaScript to show anything anyway. -->
+      <details class="feedback" id="feedback" hidden>
+        <summary>Send feedback</summary>
+        <p class="feedback-prompt">Wrong result, a missing team, something confusing? Tell us.</p>
+        <form id="feedbackForm">
+          <label for="feedbackMessage">Message</label>
+          <textarea id="feedbackMessage" name="message" rows="4" maxlength="2000" required></textarea>
+          <label for="feedbackEmail">Email (optional, for a reply)</label>
+          <input id="feedbackEmail" name="email" type="email" autocomplete="email" maxlength="254">
+          <input class="hp" name="website" type="text" tabindex="-1" autocomplete="off" aria-hidden="true">
+          <button class="btn-primary" type="submit">Send</button>
+        </form>
+        <p class="feedback-note" id="feedbackNote" aria-live="polite"></p>
+        <p class="feedback-privacy">Your message goes to our own private storage and is deleted
+          automatically after 180&nbsp;days. We can't delete an individual message on request.
+          Email is optional and used only to reply to you.</p>
+      </details>
     </div>
 
     <div class="main">
@@ -4592,6 +4678,9 @@
       const t = e.target;
       const typing = t.closest && t.closest('input, select, textarea, [contenteditable="true"]');
       if (typing) return;
+      // An open feedback panel owns the keyboard: '/' would otherwise jump to the team search
+      // from the panel's Send button or summary, which are not caught by the check above.
+      if (t.closest && t.closest('#feedback[open]')) return;
       if (e.key === '/' && !e.ctrlKey && !e.metaKey && !e.altKey) { e.preventDefault(); focusTeamSearch(); return; }
       if (e.key === 'Escape' && document.getElementById('sidebar').classList.contains('open')) { toggleSidebar(); return; }
       // Enter/Space activates focusable list items that aren't native buttons.
@@ -4618,6 +4707,50 @@
       const b = e.target.closest('.conference-item[data-conf]');
       if (b) selectConference(b.dataset.conf);
     });
+
+    // ========== FEEDBACK ==========
+    // POST /api/feedback (worker.js) writes one record into the FEEDBACK KV namespace. The
+    // panel is revealed here rather than in the markup because there is no no-JavaScript path.
+    const feedbackPanel = document.getElementById('feedback');
+    const feedbackForm = document.getElementById('feedbackForm');
+    const feedbackNote = document.getElementById('feedbackNote');
+    if (feedbackPanel && feedbackForm && feedbackNote) {
+      feedbackPanel.hidden = false;
+      feedbackForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const button = feedbackForm.querySelector('button[type="submit"]');
+        button.disabled = true;
+        feedbackNote.classList.remove('is-ok');
+        feedbackNote.textContent = 'Sending…';
+        try {
+          const res = await fetch('/api/feedback', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              message: feedbackForm.elements.message.value,
+              email: feedbackForm.elements.email.value,
+              website: feedbackForm.elements.website.value,
+              // Which view was open, so "the standings look wrong" says which standings.
+              hash: location.hash,
+            }),
+          });
+          const data = await res.json().catch(() => ({}));
+          if (res.ok) {
+            feedbackForm.hidden = true;
+            feedbackNote.textContent = 'Thanks — got it.';
+            feedbackNote.classList.add('is-ok');
+            feedbackNote.tabIndex = -1;
+            feedbackNote.focus({ preventScroll: true });
+            return;
+          }
+          // Anything the server refused leaves the form up with the typed text intact.
+          feedbackNote.textContent = data.error || 'Something went wrong. Please try again.';
+        } catch {
+          feedbackNote.textContent = 'Couldn’t reach the server. Please try again.';
+        }
+        button.disabled = false;
+      });
+    }
 
     // ========== INIT ==========
     (async () => {

--- a/worker.js
+++ b/worker.js
@@ -36,10 +36,12 @@ export default {
         return Response.redirect(url.toString(), 301);
       }
       if (isFeedback) return await feedback(request, env);
-    } catch {
+    } catch (err) {
       // A fault in the feedback handler must not take page serving down with it. The request
       // body may already be spent by now, so the feedback path answers for itself instead of
-      // handing a consumed request to the assets binding.
+      // handing a consumed request to the assets binding. The fault is logged first, so a
+      // production 503 leaves a trace in `wrangler tail` instead of failing silently.
+      console.error('feedback', err);
       if (isFeedback) return json({ ok: false, error: 'Something went wrong. Please try again.' }, 503);
     }
     return env.ASSETS.fetch(request);
@@ -64,11 +66,13 @@ async function feedback(request, env) {
   // A deploy that lost the binding should say so rather than throw on the put below.
   if (!env.FEEDBACK) return reply(503, 'Feedback is not available right now. Please try again later.');
 
-  // Measure before reading (see MAX_BODY).
+  // Measure before reading (see MAX_BODY). A negative length is as bogus as an unparseable one,
+  // and Number('-5') is finite, so it needs a check of its own.
   const declared = request.headers.get('content-length');
   const size = declared ? Number(declared) : NaN;
-  if (!Number.isFinite(size)) return reply(411, 'Please try again.');
-  if (size > MAX_BODY) return reply(413, 'Please keep it under 2,000 characters.');
+  if (!Number.isFinite(size) || size < 0) return reply(411, 'Please try again.');
+  // This one is about the whole body, not the message: say so rather than talk about characters.
+  if (size > MAX_BODY) return reply(413, 'That request was too large.');
 
   let body = {};
   try {
@@ -79,20 +83,26 @@ async function feedback(request, env) {
   // JSON.parse can return null or a scalar; neither can be dereferenced below.
   if (!body || typeof body !== 'object') body = {};
 
-  // Honeypot: real visitors never see the "website" field. Pretend it worked and store nothing.
-  if (body.website) return reply(200);
+  // Honeypot: real visitors never see this field. The name is deliberately odd because browser
+  // address autofill ignores autocomplete="off" and recognises ordinary names like "website" —
+  // a visitor whose browser filled it would be thanked while their message was dropped.
+  if (body['hp-note']) return reply(200);
 
   const message = String(body.message || '').trim();
   if (!message) return reply(400, 'Please add a message.');
   if (message.length > MAX_MESSAGE) return reply(400, 'Please keep it under 2,000 characters.');
 
-  // The email is optional, so it is only checked when the visitor gave one.
+  // The email is optional, so it is only checked when the visitor gave one. This regex and the
+  // browser's type="email" check disagree at the edges; the server's answer is the one that
+  // counts, and a disagreement just shows the 400 copy instead of storing anything.
   const email = String(body.email || '').trim().toLowerCase();
   if (email && (!EMAIL.test(email) || email.length > 254)) {
     return reply(400, 'Please enter a valid email address.');
   }
 
-  // The one thing recorded about the page rather than the person: which view was open.
+  // The one thing recorded about the page rather than the person: which view was open. slice()
+  // can cut a surrogate pair at the cap; the leftover is still a storable string, and no hash the
+  // site produces comes near MAX_HASH anyway.
   const hash = String(body.hash || '').trim().slice(0, MAX_HASH);
 
   // One key per submission. The email cannot be the key: it is optional and not unique. The ISO

--- a/worker.js
+++ b/worker.js
@@ -1,21 +1,113 @@
 // Entry point for the deployed Worker. The site itself is the static files in
-// public/ (see [assets] in wrangler.toml); this script exists only to send the
-// workers.dev address to the canonical custom domain. It runs ahead of the
-// static assets for "/" only (run_worker_first in wrangler.toml), so a page
-// view costs one Worker request and every other file is served as a free
-// static asset.
+// public/ (see [assets] in wrangler.toml). This script does two things and runs
+// ahead of the static assets for "/" and "/api/*" only (run_worker_first in
+// wrangler.toml), so a page view costs one Worker request and every other file
+// is served as a free static asset:
 //
-// Browsers carry the #fragment across a redirect, so deep links such as
-// #tab=teams&team=55477 still land on the right page.
+//   1. Sends the workers.dev address to the canonical custom domain. Browsers
+//      carry the #fragment across a redirect, so deep links such as
+//      #tab=teams&team=55477 still land on the right page.
+//   2. Accepts visitor feedback at POST /api/feedback and stores it in the
+//      FEEDBACK KV namespace, one key per submission. Stored: when it was sent,
+//      the message, the reply email if the visitor gave one, and the URL hash
+//      the visitor was on, so "the standings look wrong" says which standings.
+//      No IP address, no user agent, nothing else about the visitor.
 const CANONICAL_HOST = 'ecnl.nextonetwo.com';
+const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Matches the textarea's maxlength in public/index.html; both count UTF-16 code units.
+const MAX_MESSAGE = 2000;
+// The hash names the view (season, age group, conference, tab). Nothing real comes close to
+// this long; the cap only stops a crafted body from padding the record.
+const MAX_HASH = 200;
+// The body is two short strings, so 8 KB is generous. Without this, request.json() would let
+// Cloudflare buffer up to its 100 MB limit into this isolate — the same isolate that serves
+// the page — before anything measured it.
+const MAX_BODY = 8192;
+// Long enough to act on a report and reply, short enough that nothing lingers for years.
+const TTL_SECONDS = 180 * 24 * 60 * 60;
 
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
-    if (url.hostname.endsWith('.workers.dev')) {
-      url.hostname = CANONICAL_HOST;
-      return Response.redirect(url.toString(), 301);
+    const isFeedback = url.pathname === '/api/feedback';
+    try {
+      if (url.hostname.endsWith('.workers.dev')) {
+        url.hostname = CANONICAL_HOST;
+        return Response.redirect(url.toString(), 301);
+      }
+      if (isFeedback) return await feedback(request, env);
+    } catch {
+      // A fault in the feedback handler must not take page serving down with it. The request
+      // body may already be spent by now, so the feedback path answers for itself instead of
+      // handing a consumed request to the assets binding.
+      if (isFeedback) return json({ ok: false, error: 'Something went wrong. Please try again.' }, 503);
     }
     return env.ASSETS.fetch(request);
   },
 };
+
+// Feedback answers JSON and only JSON: the dashboard renders nothing without JavaScript, so
+// there is no plain-form fallback to redirect. Nothing here is cacheable, and the only caller
+// is this site's own page, so no Access-Control-* header is ever set.
+const json = (body, status) =>
+  Response.json(body, { status, headers: { 'cache-control': 'no-store' } });
+
+async function feedback(request, env) {
+  const reply = (status, error) => json(error ? { ok: false, error } : { ok: true }, status);
+
+  if (request.method !== 'POST') {
+    return Response.json({ ok: false, error: 'Method not allowed' }, {
+      status: 405,
+      headers: { allow: 'POST', 'cache-control': 'no-store' },
+    });
+  }
+  // A deploy that lost the binding should say so rather than throw on the put below.
+  if (!env.FEEDBACK) return reply(503, 'Feedback is not available right now. Please try again later.');
+
+  // Measure before reading (see MAX_BODY).
+  const declared = request.headers.get('content-length');
+  const size = declared ? Number(declared) : NaN;
+  if (!Number.isFinite(size)) return reply(411, 'Please try again.');
+  if (size > MAX_BODY) return reply(413, 'Please keep it under 2,000 characters.');
+
+  let body = {};
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+  // JSON.parse can return null or a scalar; neither can be dereferenced below.
+  if (!body || typeof body !== 'object') body = {};
+
+  // Honeypot: real visitors never see the "website" field. Pretend it worked and store nothing.
+  if (body.website) return reply(200);
+
+  const message = String(body.message || '').trim();
+  if (!message) return reply(400, 'Please add a message.');
+  if (message.length > MAX_MESSAGE) return reply(400, 'Please keep it under 2,000 characters.');
+
+  // The email is optional, so it is only checked when the visitor gave one.
+  const email = String(body.email || '').trim().toLowerCase();
+  if (email && (!EMAIL.test(email) || email.length > 254)) {
+    return reply(400, 'Please enter a valid email address.');
+  }
+
+  // The one thing recorded about the page rather than the person: which view was open.
+  const hash = String(body.hash || '').trim().slice(0, MAX_HASH);
+
+  // One key per submission. The email cannot be the key: it is optional and not unique. The ISO
+  // timestamp makes `kv key list` come back in chronological order and readable by eye; the random
+  // suffix keeps two submissions in the same millisecond apart. Repeating the email as metadata
+  // lets a listing show whether there is a reply address without fetching every record.
+  const suffix = [...crypto.getRandomValues(new Uint8Array(4))]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+  const record = { sent: new Date().toISOString(), message };
+  if (email) record.email = email;
+  if (hash) record.hash = hash;
+  await env.FEEDBACK.put(`${record.sent}-${suffix}`, JSON.stringify(record), {
+    metadata: { email: email || null },
+    expirationTtl: TTL_SECONDS,
+  });
+  return reply(200);
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,10 +1,12 @@
 # Cloudflare Workers config for the site.
 #
 # The site is the static files in public/ — the same directory the local
-# server serves, so the deployed site is byte-identical to a local run. The
-# tiny worker.js only redirects the workers.dev address to the canonical
-# custom domain; it runs ahead of the assets for "/" alone, so everything
-# else is served as free static assets without invoking the Worker.
+# server serves, so the deployed site is byte-identical to a local run (minus
+# the feedback panel, which needs the Worker; use `npx wrangler dev` to run
+# the full thing). worker.js redirects the workers.dev address to the
+# canonical custom domain and handles POST /api/feedback; it runs ahead of the
+# assets for "/" and "/api/*" alone, so everything else is served as free
+# static assets without invoking the Worker.
 #
 # Canonical address: https://ecnl.nextonetwo.com  (custom domain, attached to
 # this Worker in the Cloudflare dashboard under Settings -> Domains & Routes).
@@ -16,4 +18,16 @@ compatibility_date = "2026-08-31"
 [assets]
 directory = "./public"
 binding = "ASSETS"
-run_worker_first = ["/"]
+run_worker_first = ["/", "/api/*"]
+
+# Visitor feedback, one key per submission. Create the namespace once with
+# `npx wrangler kv namespace create FEEDBACK` and paste the id it prints in
+# place of the placeholder below.
+#
+# !!! DO NOT MERGE WHILE THE ID BELOW IS STILL THE PLACEHOLDER !!!
+# Pushes to main deploy automatically. A placeholder id fails the deploy, the
+# failure is silent, and a Worker that will not deploy also freezes the data
+# refresh that pushes to this repo.
+[[kv_namespaces]]
+binding = "FEEDBACK"
+id = "REPLACE_ME_WITH_REAL_KV_NAMESPACE_ID_BEFORE_MERGE"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,14 +20,15 @@ directory = "./public"
 binding = "ASSETS"
 run_worker_first = ["/", "/api/*"]
 
-# Visitor feedback, one key per submission. Create the namespace once with
-# `npx wrangler kv namespace create FEEDBACK` and paste the id it prints in
-# place of the placeholder below.
+# Visitor feedback, one key per submission. The namespace already exists on the
+# NextOneTwoLabs account and its real id is in place, so there is nothing to
+# swap before merge.
 #
-# !!! DO NOT MERGE WHILE THE ID BELOW IS STILL THE PLACEHOLDER !!!
-# Pushes to main deploy automatically. A placeholder id fails the deploy, the
-# failure is silent, and a Worker that will not deploy also freezes the data
-# refresh that pushes to this repo.
+# Its title there is ECNL_FEEDBACK, not FEEDBACK: the account already holds a
+# FEEDBACK namespace belonging to the sibling marketing site (see
+# NextOneTwoLabs/nextonetwo-website), and two stores sharing one name would be
+# indistinguishable in the dashboard. The binding stays FEEDBACK, so the
+# handler's env.FEEDBACK is unaffected by the title.
 [[kv_namespaces]]
 binding = "FEEDBACK"
-id = "REPLACE_ME_WITH_REAL_KV_NAMESPACE_ID_BEFORE_MERGE"
+id = "caf080c2c3f94556ad15cbcedca25ccd"


### PR DESCRIPTION
## Goal

Resolve #26 — visitors have no way to report a wrong score, a missing team or a confusing view without a GitHub account. This adds a **Send feedback** panel at the foot of the sidebar that posts a message (and an optional reply address) to the site's own Cloudflare Worker, which stores it in a private `FEEDBACK` KV namespace. No third party, no account needed by the sender, nothing leaves the owner's Cloudflare account.

Closes #26

**The namespace now exists on the NextOneTwoLabs account and its real id is in `wrangler.toml`, so there is no merge gate left** — its title there is `ECNL_FEEDBACK` rather than `FEEDBACK`, to avoid colliding with the sibling marketing site's namespace on the same account, while the binding stays `FEEDBACK`.

## Summary of change

Five files. This follows the sibling site's merged feedback feature, NextOneTwoLabs/nextonetwo-website#36 — same POST-only handler, same honeypot, same validation order and error copy, same record shape and metadata, same `<details>` panel — with **three deliberate deviations the owner approved on the issue**: a `Content-Length` guard before the body is read, a 180-day `expirationTtl` on every record, and one page-context field (the URL hash). The sibling's no-JavaScript branch is dropped entirely: its page is static HTML, this dashboard renders nothing without JavaScript, so the handler answers JSON only.

- **`worker.js`** — new `feedback()` handler dispatched from the existing `fetch` alongside the workers.dev redirect, whose behaviour is unchanged. POST only (`405` + `allow: POST`); `503` if the `FEEDBACK` binding is missing, so a misconfigured deploy fails safe instead of throwing; a `Content-Length` guard before the body is read (`411` absent/unparseable, `413` over 8 KB); JSON body with a `!body || typeof body !== 'object'` guard so a literal `null`, string, number or array cannot be dereferenced; honeypot field returns success and stores nothing (renamed `website` -> `hp-note` in the follow-up commit below); message trimmed, required, capped at 2,000 UTF-16 units; email optional, trimmed, lowercased, validated only when non-empty, capped at 254; the URL hash trimmed and capped at 200. One key per submission, `<ISO 8601>-<8 random hex>`, value `{sent, message}` plus `email` and `hash` only when present, metadata `{email: email || null}`, `expirationTtl` 180 days. A `try`/`catch` around the dispatch keeps a fault in the handler from taking page serving down; the feedback path answers for itself rather than handing an already-consumed request to `env.ASSETS`. Every feedback response is JSON with `Cache-Control: no-store` and no `Access-Control-*` header.
- **`wrangler.toml`** — a `[[kv_namespaces]]` `FEEDBACK` binding (its real id landed in the follow-up commit below); `run_worker_first = ["/", "/api/*"]`, matching the sibling.
- **`public/index.html`** — a `<details id="feedback">` panel below the shortcut hints in the sidebar footer: summary styled as a link, a short prompt, `<label for>` on both fields, `<textarea maxlength="2000" required>`, an optional `<input type="email">`, the off-screen honeypot (`tabindex="-1" autocomplete="off" aria-hidden="true"`), a Send button and a `<p aria-live="polite">` note, plus a plain-language privacy line (private storage, deleted automatically after 180 days, per-message deletion is not offered — see the follow-up commit below for the corrected wording — email optional and used only to reply). Styled with existing tokens (`--accent-text`, `--border`, `--bg-surface`, `--bg-surface-alt`, `--text-secondary`, `--radius-sm`); the fields join the existing 44px touch-target block and the existing `:focus-visible` rule. On submit the script POSTs `{message, email, <honeypot>, hash: location.hash}` (the honeypot key is renamed in the follow-up commit below), disables the button and shows "Sending…"; success hides the form, shows "Thanks — got it." and moves focus to the note; failure shows the server's `error` and **keeps the typed text**. The global keydown handler now stands down while focus is inside an open panel, so `/` and the arrow shortcuts no longer act from the panel's Send button or summary (narrowed in the follow-up commit below so it no longer swallows Escape). The panel is `hidden` in the markup and revealed by the script, since it has no plain-POST fallback.
- **`README.md`** — a Feedback section: the endpoint, the record shape, the 180-day expiry, that the message is free text that can carry personal details the site never asked for, how to read submissions back (`kv key list` then `kv key get`, with `--local` for the simulated store), a warning that a listing prints every reply email and must never be pasted into a public issue, and the WAF note (free plan, one rule per account, match `/api/*`; the 1,000/day KV write budget is **per account and shared with the sibling site's waiting list**). Layout table gains `worker.js` and `wrangler.toml` rows.
- **`.gitignore`** — `.wrangler/` and `node_modules/`. The refresh workflow commits with `git add -A`, so a local `npx wrangler dev` run would otherwise push its simulated KV store to the repo.
- **`wrangler.toml` and `README.md`, follow-up commit `a4bcf44`** — the placeholder id is replaced with the real KV namespace id, which the TPM created on the owner's Cloudflare account at the owner's request. Its title there is `ECNL_FEEDBACK`, not `FEEDBACK`: the account already holds a `FEEDBACK` namespace belonging to the sibling marketing site (NextOneTwoLabs/nextonetwo-website), and two stores sharing one name would be indistinguishable in the dashboard. The binding is unchanged, so `env.FEEDBACK` and the documented `--binding FEEDBACK` commands work as written. The README no longer tells the owner to create the namespace, and the do-not-merge warning is gone from both files.
- **Review follow-up, commit `6ab6b2c`** — the reviewer's approve-with-changes items, three files, no behaviour change beyond them. **The honeypot is renamed `website` -> `hp-note`** in the markup, the client's POST body and the handler: Chrome's address autofill ignores `autocomplete="off"` and recognises url-ish field names, so a visitor whose browser filled it saw "Thanks — got it." while their message was silently discarded — the one silent data-loss path in the system. Semantics are unchanged (truthy → `200`, store nothing), as are the accessibility attributes, and a comment in each file says why the name is deliberately odd. The `catch` in `worker.js` now runs `console.error('feedback', err)` before its `503`, so a production fault leaves a trace in `wrangler tail` instead of nothing. The panel's privacy line names the page context it stores ("We also store which view of the site you were on"). "We can't delete an individual message" was not literally true — `wrangler kv key delete` exists and the metadata email makes an emailed record findable — so the panel and the README now say **"We don't offer per-message deletion"**, with the README naming the manual path without advertising it. The keydown guard is narrowed to `/` and the arrow shortcuts only, so **Escape again closes the sidebar drawer** on mobile while the panel is open. The `Content-Length` guard also rejects a negative length (`Number('-5')` is finite, so `-5` passed), and the `413` copy now describes an oversized body — "That request was too large." — rather than the message's 2,000-character cap. The surrogate-pair slice and the `type="email"` vs server-regex difference are left as they were, with a comment on each.

## Testing plan

Syntax and structure

- [x] `node --check worker.js` — OK
- [x] Main inline `<script>` extracted from `public/index.html` and parsed with `new Function(body)` — OK (2,644 lines)
- [x] `git diff --stat origin/main...HEAD` — exactly the five files above; every file still pure CRLF in the working tree and pure LF in the blob, matching `origin/main`

Worker, against `npx wrangler dev` local-only (real status codes and bodies)

- [x] `GET /api/feedback` → `405 Method Not Allowed`, `Allow: POST`, `{"ok":false,"error":"Method not allowed"}`
- [x] `HEAD /api/feedback` → `405`, `Allow: POST`
- [x] POST chunked, no `Content-Length` → `411 Length Required`, `{"ok":false,"error":"Please try again."}`
- [x] POST with `Content-Length: 9000` → `413 Payload Too Large`, `{"ok":false,"error":"Please keep it under 2,000 characters."}`
- [x] Empty message → `400`, `{"ok":false,"error":"Please add a message."}`
- [x] Whitespace-only message → `400`, same body
- [x] Message of exactly 2,000 characters → `200 {"ok":true}` (stored)
- [x] Message of 2,001 characters → `400`, `{"ok":false,"error":"Please keep it under 2,000 characters."}`
- [x] Bad email → `400`, `{"ok":false,"error":"Please enter a valid email address."}`
- [x] Whitespace-only email → `200 {"ok":true}`, stored with no `email` field
- [x] Honeypot filled → `200 {"ok":true}`, and the message is absent from the KV store
- [x] Body of literal `null`, and body of `[1,2,3]` → `400 "Please add a message."` (no dereference throw)
- [x] Good submission → `200 {"ok":true}`
- [x] `GET /` → `200`; `GET /favicon.svg` → `200` (static assets unaffected)
- [x] Every feedback response carries `Cache-Control: no-store` and no `Access-Control-*` header
- [x] `wrangler kv key list --binding FEEDBACK --local` then `kv key get`: keys read `2026-09-10T20:38:34.340Z-7640bae6`; the record with an address is `{"sent":…,"message":…,"email":"parent@example.com","hash":"#season=2026-27&age=GU16&conf=NorCal&view=standings"}`, the one without is `{"sent":…,"message":…}` — `email` and `hash` omitted entirely; metadata is `{"email":"parent@example.com"}` / `{"email":null}`; the listed `expiration` is exactly 180.0 days after `sent`; grepping every byte of the local KV store for `127.0.0.1`, `user-agent`, `curl/`, `x-forwarded`, `cf-connecting`, `Mozilla` and `::1` returns nothing, and only 4 blobs exist for 5 successful POSTs (the honeypot one was not written)

Client, Playwright driving system Chrome against `python -m http.server` in `public/`, `/api/feedback` stubbed with `page.route` — **29 checks, 0 failed**

- [x] The panel is revealed by the script, starts closed, opens and closes on the summary
- [x] Both `<label for>` really resolve (`label.control === input`, `input.labels.length === 1`)
- [x] Honeypot is not in the real tab order (Tab walk from the summary: message → email → button → …), is `tabindex="-1" aria-hidden="true"`, and sits at `left: -9999px`
- [x] `maxlength="2000"` clamps 2,500 characters typed through CDP `Input.insertText` to exactly 2,000
- [x] `/` with focus on the Send button, and on the open panel's summary, does **not** jump to team search; `ArrowRight` inside the open panel does not change the view; `/` outside the panel still focuses team search (unchanged)
- [x] Submit posts `{message, email, website, hash}` as `application/json`; stubbed `200` hides the form, shows "Thanks — got it." and moves focus to the `aria-live="polite"` note
- [x] Stubbed `400` shows the server's error text, keeps the form up, **keeps the typed message and email**, and re-enables the Send button
- [x] An empty required message is blocked by native constraint validation — no request is sent
- [x] At 375px nothing overflows the viewport, summary/email/button are all ≥ 44px tall, and the panel submits
- [x] Zero console errors (excluding the pre-existing `/favicon.ico` 404 and Chrome's own network log line for the deliberately stubbed 400)
- [x] Panel renders correctly in both themes from existing tokens (screenshots taken in light and dark)

Review follow-up, commit `6ab6b2c` (re-run against `npx wrangler dev` local-only; real status codes)

- [x] `node --check worker.js` — OK; inline `<script>` re-extracted from `public/index.html` and parsed with `new Function(body)` — OK (2,649 lines, 133,778 chars)
- [x] Honeypot filled under its **new** name `hp-note` → `200 {"ok":true}`, and nothing was written — `kv key list` held no record for it
- [x] The **old** name `website` filled while `hp-note` is empty → `200` and the message **is** stored, which is the proof the rename reached the handler rather than being ignored on both sides
- [x] Good submission → `200 {"ok":true}`, exactly one new key; read back with `kv key get`: `{"sent":…,"message":"The GU16 NorCal standings look wrong for Mustang.","email":"parent@example.com","hash":"#season=2026-27&age=GU16&conf=NorCal&view=standings"}`, metadata `{"email":"parent@example.com"}` — **the field set is unchanged**, and no `website`/`hp-note` key is stored
- [x] `GET /api/feedback` → `405 Method Not Allowed`, `Allow: POST`
- [x] POST chunked, no `Content-Length` → `411 Length Required`
- [x] POST `Content-Length: 9000` with a real 9,000-byte body → `413 Payload Too Large`, `{"ok":false,"error":"That request was too large."}` — the new copy
- [x] `Content-Length: -5` — over HTTP, wrangler's own parser answers `500` before the Worker runs, so the negative can only be delivered to the handler directly; invoking `worker.fetch` with a synthetic request gives `-5` → `411` and `-1` → `411` (both reached `413`-free code and **passed** the guard before this commit), with `abc` and an absent header still `411`
- [x] Forcing the handler to throw → `503` **and** `feedback Error: …` on the console, which is the log the `catch` was missing
- [x] `GET /` → `200`; the homepage still serves
- [x] Every feedback response still carries `Cache-Control: no-store` and no `Access-Control-*` header

Client, Playwright driving system Chrome, `/api/feedback` stubbed with `page.route` — **30 checks, 0 failed**

- [x] Under the new name the honeypot is still `tabindex="-1"`, `aria-hidden="true"`, `autocomplete="off"`, positioned at `left: -9999px`, has no `<label>`, and never appears in a Tab walk (summary → message → email → button)
- [x] The submitted JSON carries `hp-note` and **no** `website` key; `message`, `email` and `hash` are unchanged
- [x] Stubbed `200` still hides the form, shows "Thanks — got it." and moves focus to the note
- [x] Stubbed `400` still keeps the typed message and email, shows the server's error and re-enables Send
- [x] `/` inside the open panel (summary and Send button) still does nothing; `/` outside still focuses team search; arrow keys inside the open panel still do not change the view
- [x] **At 375px with the drawer open and the panel open, Escape now closes the drawer** — from the summary and from the Send button. Control: the same steps against the pre-fix document (served to the same origin via `page.route`) leave `sidebar.open = true`, confirming the regression was real
- [x] The privacy line renders as "Your message goes to our own private storage and is deleted automatically after 180 days. We don't offer per-message deletion. Email is optional and used only to reply to you. We also store which view of the site you were on."
- [x] Zero console errors
- [x] `git diff --stat origin/main...HEAD` — still the same five files; working tree pure CRLF, committed blobs pure LF, matching `origin/main`

Not verified here, and needing the owner or a live deploy

- [ ] Real (`--remote`) KV: the namespace does not exist yet, so every KV assertion above is against wrangler's local simulation. The 180-day `expirationTtl` and the metadata shape are confirmed locally but not against Cloudflare's API.
- [ ] The deploy itself, and that `run_worker_first = ["/", "/api/*"]` routes `/api/feedback` to the Worker in production rather than to the assets 404.
- [ ] The WAF rate-limiting rule — an owner action in the Cloudflare dashboard, not in this repo.
- [ ] Read-only KV token for triage, so the team can list and get without full account credentials.
- [ ] Website Auditor verifies live after merge

## Potential risks and suggestions

- **Spam beyond the honeypot.** The honeypot plus the 2,000-character and 8 KB caps bound each write, not how many arrive. Plan v3 deliberately dropped in-Worker rate limiting, so until the WAF rule exists a determined script can write as fast as it can POST. The 1,000/day free-plan KV write budget is the real ceiling, and hitting it is the failure mode below.
- **The KV write budget is per account and shared.** Free-plan KV writes are capped at 1,000 a day for the whole Cloudflare account, shared with the sibling site's waiting list — a flood of feedback here would break signups on `nextonetwo.com` too. The free plan allows one WAF rate-limiting rule per account, so a single rule matching `/api/*` covers both sites; that is the recommended mitigation.
- **The privacy surface of free text.** The message field is unvalidated free text: a parent can type a player's name, a club, a phone number or an address the site never asked for and cannot detect. It is stored in plain text and is readable by anyone with Cloudflare dashboard or `wrangler` access. The 180-day expiry bounds how long that lasts, but per-message deletion is not offered — the panel and the README both say so, and the README names the manual `wrangler kv key delete` path without advertising it. When triaging, open the public issue in your own words and leave personal details out. A `kv key list` prints the metadata, so it prints **every** reply email: never paste one into an issue, a PR or a screenshot.
- **The sibling repo has the same unbounded-body exposure this PR guards against.** `NextOneTwoLabs/nextonetwo-website`'s `waitlist()` and `feedback()` both call `request.json()` / `request.formData()` with no size check, so Cloudflare will buffer up to its 100 MB limit into the isolate before anything measures it — and on both sites the Worker runs ahead of `/`, so an out-of-memory kill takes page requests with it. Worth a small follow-up in that repo mirroring the three-line guard added here.
- **Minor:** the panel is `hidden` in the markup and revealed by the script. If the inline script ever throws before that line, the panel silently disappears rather than rendering broken — a deliberate trade, but worth knowing when debugging a report of "the feedback link is gone".

🤖 Generated with [Claude Code](https://claude.com/claude-code)



