### PR TITLE
The README states the real refresh cadence / match-day row and a measured-practice note replace the two-hour claim / For Issue #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,26 @@ is provably nothing to fetch:
 
 | Run | Work done |
 |---|---|
-| Non-match day, not the sweep hour | exits in seconds, **0 requests** |
-| Sweep hour (daily) | all flight schedules, rebuilding the calendar |
+| Non-match day, no sweep due, nothing pending | **0 requests**, exits at once |
+| Sweep due (first run at or after the hour) | all schedules, and the calendar |
 | Match day | the flights that played, on every scheduled run |
+| A past game still missing a score | that flight, on any day, until it lands |
 
 The workflow asks for a run every two hours, but GitHub delays and drops
-scheduled jobs on shared runners. Measured over eight consecutive runs the gaps
-were 3.3 to 5.4 hours, a mean of 4.6 — so in practice it is **roughly every 3 to
-5 hours**, and on a match day that is how quickly scores appear. The daily sweep
-is not at risk from this: `archive.py` treats a sweep as due once the hour is at
-or past the configured one **and** the day has not been swept yet (the
-`due_by_hour` / `lastSweepDate` logic in `cmd_refresh`), rather than requiring a
-run to land inside a particular hour — so a late or dropped cron never skips it.
+scheduled jobs on shared runners. Over the 57 gaps between the 58 scheduled
+runs from 1 to 12 September 2026 the spread was 2.9 to 6.5 hours, mean 4.6,
+median 5.0, and 27 of the 57 ran over five hours — so in practice it is
+**roughly every 3 to 5½ hours**, and on a match day that is how quickly scores
+appear. Those are measured figures from one snapshot rather than a guarantee:
+GitHub schedules on a best-effort basis, so expect them to drift.
+
+The daily sweep is not at risk from this. `archive.py` treats a sweep as due
+once the hour is at or past the configured one (06:00 UTC) **and** the day has
+not been swept yet — the `due_by_hour` / `lastSweepDate` logic in
+`cmd_refresh` — rather than requiring a run to land inside a particular hour,
+so a late or dropped run never skips it. Losing *every* run from 06:00 UTC
+onward on a given day is the one case that does: nothing is left that day to
+notice the sweep is due.
 
 Standings are only refetched where a **result actually changed** — schedule
 payloads carry scores, so a schedule fetch collects results too, and standings
@@ -248,7 +256,7 @@ the one rule covers both sites.
 | `worker.js` | Redirects the `workers.dev` hostname, and handles `POST /api/feedback` |
 | `wrangler.toml` | Cloudflare Workers config: the `public/` assets and the `FEEDBACK` KV binding |
 | `.gitattributes` | Pins the image assets (`*.svg`, `*.png`) as binary, so the files copied from the entrance site stay byte-identical across checkouts instead of being line-ending converted |
-| `.github/workflows/refresh.yml` | The scheduled refresh — asks for every 2 h, in practice every 3-5 |
+| `.github/workflows/refresh.yml` | The scheduled refresh — asks for every 2 h, measured at 3 to 5½ |
 | `ecnl-standings.html` | Deprecated first version, kept for reference |
 
 ## Deploying

--- a/README.md
+++ b/README.md
@@ -59,7 +59,16 @@ is provably nothing to fetch:
 |---|---|
 | Non-match day, not the sweep hour | exits in seconds, **0 requests** |
 | Sweep hour (daily) | all flight schedules, rebuilding the calendar |
-| Match day | the flights that played, every 2 h |
+| Match day | the flights that played, on every scheduled run |
+
+The workflow asks for a run every two hours, but GitHub delays and drops
+scheduled jobs on shared runners. Measured over eight consecutive runs the gaps
+were 3.3 to 5.4 hours, a mean of 4.6 — so in practice it is **roughly every 3 to
+5 hours**, and on a match day that is how quickly scores appear. The daily sweep
+is not at risk from this: `archive.py` treats a sweep as due once the hour is at
+or past the configured one **and** the day has not been swept yet (the
+`due_by_hour` / `lastSweepDate` logic in `cmd_refresh`), rather than requiring a
+run to land inside a particular hour — so a late or dropped cron never skips it.
 
 Standings are only refetched where a **result actually changed** — schedule
 payloads carry scores, so a schedule fetch collects results too, and standings
@@ -239,7 +248,7 @@ the one rule covers both sites.
 | `worker.js` | Redirects the `workers.dev` hostname, and handles `POST /api/feedback` |
 | `wrangler.toml` | Cloudflare Workers config: the `public/` assets and the `FEEDBACK` KV binding |
 | `.gitattributes` | Pins the image assets (`*.svg`, `*.png`) as binary, so the files copied from the entrance site stay byte-identical across checkouts instead of being line-ending converted |
-| `.github/workflows/refresh.yml` | The 2-hourly scheduled refresh |
+| `.github/workflows/refresh.yml` | The scheduled refresh — asks for every 2 h, in practice every 3-5 |
 | `ecnl-standings.html` | Deprecated first version, kept for reference |
 
 ## Deploying


### PR DESCRIPTION
## Goal

Resolve #36 — the README claimed the match-day refresh runs "every 2 h", which
GitHub's scheduler has never actually delivered; this makes the documented
cadence match the measured one.

Closes #36

## Summary of change

Two locations in `README.md` asserted the two-hour cadence. A grep for `2 h`,
`two hours`, `2-hourly`, `every 2` and `hourly` found these and nothing else
(the only other `cron` hit, at L183, is about feedback-message retention and is
unrelated).

1. **The refresh table, match-day row.** Was "the flights that played,
   **every 2 h**"; now "the flights that played, on every scheduled run". The row
   states what the run does; the cadence moved out of the table so it can be
   qualified.
2. **New prose directly under that table**, in two paragraphs. The first says the
   workflow asks for every two hours but GitHub delays and drops scheduled jobs
   on shared runners, and gives the measured spread — 2.9 to 6.5 hours, mean 4.6,
   median 5.0, with 27 of 57 gaps over five hours — so in practice **roughly
   every 3 to 5½ hours**, which on a match day is how quickly scores appear. The
   second records the part that is well built and should not be "fixed": the
   daily sweep self-heals, because `archive.py` treats a sweep as due once the
   hour is at or past the configured one (06:00 UTC) **and** the day has not been
   swept yet (the `due_by_hour` / `lastSweepDate` logic in `cmd_refresh`), rather
   than requiring a run to land inside a particular hour — so a late or dropped
   run never skips it.
3. **The file table entry for `.github/workflows/refresh.yml`.** Was "The
   2-hourly scheduled refresh"; now "The scheduled refresh — asks for every 2 h,
   measured at 3 to 5½", so the one-line description does not repeat the claim
   the section above just corrected.
4. **Review follow-up (`4d712d0`).** Applied the Reviewer's approve-with-changes
   items after re-measuring the schedule independently. The cadence was widened
   from "3 to 5 hours" — which 27 of 57 observed gaps exceeded — to "3 to 5½",
   quoted beside the full spread and labelled a measured snapshot rather than a
   guarantee. "a late or dropped **cron**" became "a late or dropped **run**",
   with the one case that does skip spelled out (losing every run from 06:00 UTC
   onward on a day). The table row "Sweep hour (daily)" became "Sweep due (first
   run at or after the hour)" so the table and the prose agree. The "0 requests"
   row was qualified with "nothing pending" and a pending-results row added,
   because `candidates |= set(pending)` adds pending-result flights independently
   of sweep and match day. The single paragraph was split in two. The layout
   table's "Updated 3h ago" was deliberately left alone — it illustrates the UI
   string's format, and 3h sits inside the measured spread.

`minIntervalMinutes` is not mentioned anywhere in the README, so per the issue no
mention was added. The existing voice, ~80-column wrapping and CRLF line endings
are preserved; the section and table are otherwise untouched. The workflow's own
"Runs every 2 hours" comment and the inert `everyHours` setting are out of scope
here and tracked in #38.

## Testing plan

This is a documentation-only change. No workflow, config, or code was modified,
so there is no behaviour to exercise and nothing to run — the checks below are
scope and consistency checks on the text itself, plus the measurement the text
now quotes.

- [x] **Cadence re-measured independently** before any number was written:
      `gh run list --workflow refresh.yml --limit 60 --json createdAt,conclusion,event`,
      filtered to `event == "schedule"`. 58 scheduled runs, 2026-09-01T23:51Z to
      2026-09-12T20:18Z, all `success`, giving 57 gaps:
      **min 2.93 h, max 6.52 h, mean 4.57 h, median 4.95 h**, with **27 of 57
      gaps over 5.0 h**, 5 over 5.5 h and 1 over 6.0 h. This reproduces the
      Reviewer's figures exactly and is what the README now states.
- [x] `git diff --stat origin/main...HEAD` → `README.md | 25 ++++++++++----`,
      1 file changed, 21 insertions(+), 4 deletions(-). Still README.md only;
      `git status --porcelain` is clean.
- [x] `grep -i -n` for `2 h`, `two hours`, `every 2`, `3 to 5` and `never skips`
      → the only survivors are the qualified lines: "asks for a run every two
      hours, but GitHub delays and drops…", "roughly every 3 to 5½ hours",
      "asks for every 2 h, measured at 3 to 5½", and "a late or dropped **run**
      never skips it". `sweep hour`, `3-5` and `eight consecutive` no longer
      match anywhere. No stale or overclaiming assertion survives.
- [x] CRLF preserved: 370 CRLF, 0 bare LF, 0 bare CR.
- [x] Line widths: every added prose line and every added refresh-table row is
      ≤ 80 columns. One added line exceeds it — the `refresh.yml` row in the
      layout table at 101 columns — which matches that table's existing
      convention (neighbouring rows are 88, 99 and 193) and is 2 columns
      shorter than the line it replaces.
- [x] The self-heal claim was checked against the source, not assumed:
      `archive.py` `cmd_refresh` L619-621 (`swept_on` / `due_by_hour` / `sweep`),
      `sweepAtUtcHour` defaulting to 6 at L574, and the candidate set at L626-631
      where `candidates |= set(pending)` sits outside both the sweep and
      match-day branches.
- [ ] Website Auditor verifies live after merge — for a documentation-only change
      this means confirming the README renders correctly on GitHub (the table and
      the new paragraphs); there is nothing to check on the live site, since no
      shipped asset changed.

## Potential risks and suggestions

- **The figures are a snapshot and will drift.** They come from one 11-day
  window of 58 runs on GitHub's shared runners, where scheduling delay varies
  with load. The README now says so in the text itself — "measured figures from
  one snapshot rather than a guarantee" — but the range will need re-measuring
  before anyone quotes it as a commitment, and a quieter or busier period could
  move the mean and push the max outside the stated range again. The observed
  max of 6.52 h already sits above the 5½ figure; 5½ describes the typical gap,
  and the full 2.9-6.5 spread is stated alongside it for that reason.
- Whether to ask for the cron more often (so that after GitHub's delays the
  effective cadence lands nearer the intent) is deliberately **not** decided
  here. This PR only corrects a factual error in our own documentation and
  changes no behaviour. That option, and the alternative of rewording the
  freshness indicator in terms of the observed timestamp, stay open on #36's
  options list, to be decided after measurement rather than assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
